### PR TITLE
Bugfix/6068 incorrect submission status

### DIFF
--- a/camdecmps/views/vw_em_eval_and_submit.sql
+++ b/camdecmps/views/vw_em_eval_and_submit.sql
@@ -1,38 +1,52 @@
-CREATE OR REPLACE VIEW camdecmps.vw_em_eval_and_submit
- AS
- SELECT p.oris_code,
-    p.facility_name,
-    d.mon_plan_id,
-    d.configuration,
-    esa.userid,
-    esa.update_date AS update_date,
-    esa.window_status AS window_status,
-    rpt.period_abbreviation
-   FROM camd.plant p
-     JOIN camdecmps.monitor_plan mp USING (fac_id)
-	 JOIN (
-		SELECT mon_plan_id, string_agg(unit_stack, ', ') AS configuration
-		FROM (
-			SELECT mon_plan_id, COALESCE(unitid, stack_name) AS unit_stack
-			FROM camdecmps.monitor_plan_location mpl
-			JOIN camdecmps.monitor_location ml USING(mon_loc_id)
-			LEFT JOIN camdecmps.stack_pipe USING(stack_pipe_id)
-			LEFT JOIN camd.unit USING(unit_id)
-			ORDER BY mon_plan_id, unitid, stack_name
-		) AS d1
-		GROUP BY mon_plan_id
-	 ) AS d USING(mon_plan_id)
-     JOIN camdecmps.emission_evaluation ee USING(mon_plan_id)
-     JOIN camdecmpsmd.reporting_period rpt ON ee.rpt_period_id = rpt.rpt_period_id
-     LEFT JOIN (
-      SELECT DISTINCT ON (esa.mon_plan_id, esa.rpt_period_id)
-        esa.mon_plan_id,
-        esa.rpt_period_id,
+CREATE OR REPLACE VIEW camdecmps.vw_em_eval_and_submit AS
+SELECT
+    fac.oris_code,
+    fac.facility_name,
+    lst.mon_plan_id,
+    (
+        SELECT
+            string_agg(coalesce(unt.unitid, stp.stack_name), ', '::text ORDER BY unt.unitid, stp.stack_name)
+        FROM
+            camdecmps.monitor_plan_location mpl
+            JOIN camdecmps.monitor_location loc ON loc.mon_loc_id = mpl.mon_loc_id
+            LEFT JOIN camd.unit unt ON unt.unit_id = loc.unit_id
+            LEFT JOIN camdecmps.stack_pipe stp ON stp.stack_pipe_id = loc.stack_pipe_id
+        WHERE
+            mpl.mon_plan_id = lst.mon_plan_id) AS configuration,
         esa.userid,
-        COALESCE(esa.update_date, esa.add_date) AS update_date,
-        esa.sub_availability_cd AS window_status
-      FROM camdecmpsaux.em_submission_access esa
-      WHERE esa.em_status_cd::text <> 'RECVD'::text
-      ORDER BY esa.mon_plan_id, esa.rpt_period_id, esa.access_begin_date DESC
-	) esa ON ee.mon_plan_id::text = esa.mon_plan_id::text AND ee.rpt_period_id = esa.rpt_period_id
-	ORDER BY p.oris_code, configuration, rpt.period_abbreviation;
+        esa.update_date,
+        esa.sub_availability_cd AS window_status,
+        prd.period_abbreviation
+    FROM (
+        SELECT
+            ems.mon_plan_id,
+            ems.rpt_period_id,
+            (
+                SELECT
+                    esa.em_sub_access_id
+                FROM (
+                    SELECT
+                        sel.mon_plan_id,
+                        sel.rpt_period_id,
+                        max(sel.access_begin_date) AS last_access_begin_date
+                    FROM
+                        camdecmpsaux.em_submission_access sel
+                    WHERE
+                        sel.mon_plan_id = ems.mon_plan_id
+                        AND sel.rpt_period_id = ems.rpt_period_id
+                    GROUP BY
+                        sel.mon_plan_id,
+                        sel.rpt_period_id) lst
+                    JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst.mon_plan_id
+                        AND esa.rpt_period_id = lst.rpt_period_id
+                        AND esa.access_begin_date = lst.last_access_begin_date) AS last_em_sub_access_id
+                FROM
+                    camdecmps.emission_evaluation ems) lst
+JOIN camdecmpsaux.em_submission_access esa ON esa.em_sub_access_id = lst.last_em_sub_access_id
+JOIN camdecmpsmd.reporting_period prd ON prd.rpt_period_id = lst.rpt_period_id
+JOIN camdecmps.monitor_plan pln ON pln.mon_plan_id = lst.mon_plan_id
+JOIN camd.plant fac ON fac.fac_id = pln.fac_id
+ORDER BY
+    oris_code,
+    configuration,
+    period_abbreviation;

--- a/camdecmpswks/views/vw_em_eval_and_submit.sql
+++ b/camdecmpswks/views/vw_em_eval_and_submit.sql
@@ -1,48 +1,62 @@
 -- View: camdecmpswks.vw_em_eval_and_submit
-
 DROP VIEW IF EXISTS camdecmpswks.vw_em_eval_and_submit;
 
-CREATE OR REPLACE VIEW camdecmpswks.vw_em_eval_and_submit
- AS
- SELECT p.oris_code,
-    p.facility_name,
-    d.mon_plan_id,
-    d.configuration,
-    ee.eval_status_cd,
-    esc.eval_status_cd_description,
-    ee.submission_availability_cd,
-    sac.sub_avail_cd_description AS submission_availability_cd_description,
-    esa.userid,
-    esa.update_date AS update_date,
-    esa.window_status AS window_status,
-    rpt.period_abbreviation
-   FROM camd.plant p
-     JOIN camdecmpswks.monitor_plan mp USING (fac_id)
-	 JOIN (
-		SELECT mon_plan_id, string_agg(unit_stack, ', ') AS configuration
-		FROM (
-			SELECT mon_plan_id, COALESCE(unitid, stack_name) AS unit_stack
-			FROM camdecmpswks.monitor_plan_location mpl
-			JOIN camdecmpswks.monitor_location ml USING(mon_loc_id)
-			LEFT JOIN camdecmpswks.stack_pipe USING(stack_pipe_id)
-			LEFT JOIN camd.unit USING(unit_id)
-			ORDER BY mon_plan_id, unitid, stack_name
-		) AS d1
-		GROUP BY mon_plan_id
-	 ) AS d USING(mon_plan_id)
-     JOIN camdecmpswks.emission_evaluation ee USING(mon_plan_id)
-     JOIN camdecmpsmd.reporting_period rpt ON ee.rpt_period_id = rpt.rpt_period_id
-     JOIN camdecmpsmd.eval_status_code esc ON esc.eval_status_cd::text = ee.eval_status_cd::text
-     LEFT JOIN camdecmpsmd.submission_availability_code sac ON sac.submission_availability_cd::text = ee.submission_availability_cd::text
-     LEFT JOIN (
-      SELECT DISTINCT ON (esa.mon_plan_id, esa.rpt_period_id)
-        esa.mon_plan_id,
-        esa.rpt_period_id,
+CREATE OR REPLACE VIEW camdecmpswks.vw_em_eval_and_submit AS
+SELECT
+    fac.oris_code,
+    fac.facility_name,
+    lst.mon_plan_id,
+    (
+        SELECT
+            string_agg(coalesce(unt.unitid, stp.stack_name), ', '::text ORDER BY unt.unitid, stp.stack_name)
+        FROM
+            camdecmpswks.monitor_plan_location mpl
+            JOIN camdecmpswks.monitor_location loc ON loc.mon_loc_id = mpl.mon_loc_id
+            LEFT JOIN camd.unit unt ON unt.unit_id = loc.unit_id
+            LEFT JOIN camdecmpswks.stack_pipe stp ON stp.stack_pipe_id = loc.stack_pipe_id
+        WHERE
+            mpl.mon_plan_id = lst.mon_plan_id) AS configuration,
+        lst.eval_status_cd,
+        esc.eval_status_cd_description,
+        esa.sub_availability_cd AS submission_availability_cd,
+        sac.sub_avail_cd_description AS submission_availability_cd_description,
         esa.userid,
-        COALESCE(esa.update_date, esa.add_date) AS update_date,
-        esa.sub_availability_cd AS window_status
-      FROM camdecmpsaux.em_submission_access esa
-      WHERE esa.em_status_cd::text <> 'RECVD'::text
-      ORDER BY esa.mon_plan_id, esa.rpt_period_id, esa.access_begin_date DESC
-	) esa ON ee.mon_plan_id::text = esa.mon_plan_id::text AND ee.rpt_period_id = esa.rpt_period_id
-	ORDER BY p.oris_code, configuration, rpt.period_abbreviation;
+        esa.update_date,
+        esa.sub_availability_cd AS window_status,
+        prd.period_abbreviation
+    FROM (
+        SELECT
+            ems.mon_plan_id,
+            ems.rpt_period_id,
+            ems.eval_status_cd,
+            (
+                SELECT
+                    esa.em_sub_access_id
+                FROM (
+                    SELECT
+                        sel.mon_plan_id,
+                        sel.rpt_period_id,
+                        max(sel.access_begin_date) AS last_access_begin_date
+                    FROM
+                        camdecmpsaux.em_submission_access sel
+                    WHERE
+                        sel.mon_plan_id = ems.mon_plan_id
+                        AND sel.rpt_period_id = ems.rpt_period_id
+                    GROUP BY
+                        sel.mon_plan_id,
+                        sel.rpt_period_id) lst
+                    JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst.mon_plan_id
+                        AND esa.rpt_period_id = lst.rpt_period_id
+                        AND esa.access_begin_date = lst.last_access_begin_date) AS last_em_sub_access_id
+                FROM
+                    camdecmpswks.emission_evaluation ems) lst
+JOIN camdecmpsaux.em_submission_access esa ON esa.em_sub_access_id = lst.last_em_sub_access_id
+JOIN camdecmpsmd.reporting_period prd ON prd.rpt_period_id = lst.rpt_period_id
+JOIN camdecmpswks.monitor_plan pln ON pln.mon_plan_id = lst.mon_plan_id
+JOIN camd.plant fac ON fac.fac_id = pln.fac_id
+JOIN camdecmpsmd.submission_availability_code sac ON sac.submission_availability_cd::text = esa.sub_availability_cd::text
+JOIN camdecmpsmd.eval_status_code esc ON esc.eval_status_cd::text = lst.eval_status_cd::text
+ORDER BY
+    oris_code,
+    configuration,
+    period_abbreviation;


### PR DESCRIPTION
## Related Issues:
* US-EPA-CAMD/easey-ui#6068

## Main Changes:
* Updated the `vw_em_eval_and_submit` views in both the `camdecmps` and `camdecmpswks` schemas to use the latest submission access ID for the "Eval Status" and "Submission Status" columns on the Evaluate screen.
