### PR TITLE
fix(#6068): fixed issue of join removing non-submitted evaluations

### DIFF
--- a/camdecmps/views/vw_em_eval_and_submit.sql
+++ b/camdecmps/views/vw_em_eval_and_submit.sql
@@ -1,8 +1,8 @@
 CREATE OR REPLACE VIEW camdecmps.vw_em_eval_and_submit AS
 SELECT
-    p.oris_code,
-    p.facility_name,
-    mp.mon_plan_id,
+    fac.oris_code,
+    fac.facility_name,
+    pln.mon_plan_id,
     (
         SELECT
             string_agg(coalesce(unt.unitid, stp.stack_name), ', '::text ORDER BY unt.unitid, stp.stack_name)
@@ -12,24 +12,20 @@ SELECT
             LEFT JOIN camd.unit unt ON unt.unit_id = loc.unit_id
             LEFT JOIN camdecmps.stack_pipe stp ON stp.stack_pipe_id = loc.stack_pipe_id
         WHERE
-            mpl.mon_plan_id = lst.mon_plan_id) AS configuration,
-        esa.userid,
-        COALESCE(esa.update_date, esa.add_date) AS update_date,
-        esa.sub_availability_cd AS window_status,
-        rpt.period_abbreviation
-    FROM
-        camd.plant p
-        JOIN camdecmps.monitor_plan mp ON mp.fac_id = p.fac_id
-        JOIN camdecmps.emission_evaluation ee ON ee.mon_plan_id = mp.mon_plan_id
-        JOIN camdecmpsmd.reporting_period rpt ON rpt.rpt_period_id = ee.rpt_period_id
-        JOIN (
-            SELECT
-                ems.mon_plan_id,
-                ems.rpt_period_id,
-                (
-                    SELECT
-                        esa.em_sub_access_id
-                    FROM (
+            mpl.mon_plan_id = lst.mon_plan_id
+    ) AS configuration,
+    esa.userid,
+    COALESCE(esa.update_date, esa.add_date) AS update_date,
+    esa.sub_availability_cd AS window_status,
+    prd.period_abbreviation
+FROM (
+        SELECT
+            ems.mon_plan_id,
+            ems.rpt_period_id,
+            (
+                SELECT
+                    esa.em_sub_access_id
+                FROM (
                         SELECT
                             sel.mon_plan_id,
                             sel.rpt_period_id,
@@ -41,15 +37,20 @@ SELECT
                             AND sel.rpt_period_id = ems.rpt_period_id
                         GROUP BY
                             sel.mon_plan_id,
-                            sel.rpt_period_id) lst1
-                        JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst1.mon_plan_id
-                            AND esa.rpt_period_id = lst1.rpt_period_id
-                            AND esa.access_begin_date = lst1.last_access_begin_date) AS last_em_sub_access_id
-                    FROM
-                        camdecmps.emission_evaluation ems) lst ON lst.mon_plan_id = ee.mon_plan_id
-        AND lst.rpt_period_id = ee.rpt_period_id
+                            sel.rpt_period_id
+                    ) lst1
+                    JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst1.mon_plan_id
+                        AND esa.rpt_period_id = lst1.rpt_period_id
+                        AND esa.access_begin_date = lst1.last_access_begin_date
+            ) AS last_em_sub_access_id
+        FROM
+            camdecmps.emission_evaluation ems
+    ) lst
+    JOIN camdecmpsmd.reporting_period prd ON prd.rpt_period_id = lst.rpt_period_id
+    JOIN camdecmps.monitor_plan pln ON pln.mon_plan_id = lst.mon_plan_id
+    JOIN camd.plant fac ON fac.fac_id = pln.fac_id
     LEFT JOIN camdecmpsaux.em_submission_access esa ON esa.em_sub_access_id = lst.last_em_sub_access_id
 ORDER BY
-    p.oris_code,
+    oris_code,
     configuration,
-    rpt.period_abbreviation;
+    period_abbreviation;

--- a/camdecmps/views/vw_em_eval_and_submit.sql
+++ b/camdecmps/views/vw_em_eval_and_submit.sql
@@ -1,8 +1,8 @@
 CREATE OR REPLACE VIEW camdecmps.vw_em_eval_and_submit AS
 SELECT
-    fac.oris_code,
-    fac.facility_name,
-    lst.mon_plan_id,
+    p.oris_code,
+    p.facility_name,
+    mp.mon_plan_id,
     (
         SELECT
             string_agg(coalesce(unt.unitid, stp.stack_name), ', '::text ORDER BY unt.unitid, stp.stack_name)
@@ -16,37 +16,40 @@ SELECT
         esa.userid,
         COALESCE(esa.update_date, esa.add_date) AS update_date,
         esa.sub_availability_cd AS window_status,
-        prd.period_abbreviation
-    FROM (
-        SELECT
-            ems.mon_plan_id,
-            ems.rpt_period_id,
-            (
-                SELECT
-                    esa.em_sub_access_id
-                FROM (
+        rpt.period_abbreviation
+    FROM
+        camd.plant p
+        JOIN camdecmps.monitor_plan mp ON mp.fac_id = p.fac_id
+        JOIN camdecmps.emission_evaluation ee ON ee.mon_plan_id = mp.mon_plan_id
+        JOIN camdecmpsmd.reporting_period rpt ON rpt.rpt_period_id = ee.rpt_period_id
+        JOIN (
+            SELECT
+                ems.mon_plan_id,
+                ems.rpt_period_id,
+                (
                     SELECT
-                        sel.mon_plan_id,
-                        sel.rpt_period_id,
-                        max(sel.access_begin_date) AS last_access_begin_date
+                        esa.em_sub_access_id
+                    FROM (
+                        SELECT
+                            sel.mon_plan_id,
+                            sel.rpt_period_id,
+                            max(sel.access_begin_date) AS last_access_begin_date
+                        FROM
+                            camdecmpsaux.em_submission_access sel
+                        WHERE
+                            sel.mon_plan_id = ems.mon_plan_id
+                            AND sel.rpt_period_id = ems.rpt_period_id
+                        GROUP BY
+                            sel.mon_plan_id,
+                            sel.rpt_period_id) lst1
+                        JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst1.mon_plan_id
+                            AND esa.rpt_period_id = lst1.rpt_period_id
+                            AND esa.access_begin_date = lst1.last_access_begin_date) AS last_em_sub_access_id
                     FROM
-                        camdecmpsaux.em_submission_access sel
-                    WHERE
-                        sel.mon_plan_id = ems.mon_plan_id
-                        AND sel.rpt_period_id = ems.rpt_period_id
-                    GROUP BY
-                        sel.mon_plan_id,
-                        sel.rpt_period_id) lst
-                    JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst.mon_plan_id
-                        AND esa.rpt_period_id = lst.rpt_period_id
-                        AND esa.access_begin_date = lst.last_access_begin_date) AS last_em_sub_access_id
-                FROM
-                    camdecmps.emission_evaluation ems) lst
-JOIN camdecmpsaux.em_submission_access esa ON esa.em_sub_access_id = lst.last_em_sub_access_id
-JOIN camdecmpsmd.reporting_period prd ON prd.rpt_period_id = lst.rpt_period_id
-JOIN camdecmps.monitor_plan pln ON pln.mon_plan_id = lst.mon_plan_id
-JOIN camd.plant fac ON fac.fac_id = pln.fac_id
+                        camdecmps.emission_evaluation ems) lst ON lst.mon_plan_id = ee.mon_plan_id
+        AND lst.rpt_period_id = ee.rpt_period_id
+    LEFT JOIN camdecmpsaux.em_submission_access esa ON esa.em_sub_access_id = lst.last_em_sub_access_id
 ORDER BY
-    oris_code,
+    p.oris_code,
     configuration,
-    period_abbreviation;
+    rpt.period_abbreviation;

--- a/camdecmpswks/views/vw_em_eval_and_submit.sql
+++ b/camdecmpswks/views/vw_em_eval_and_submit.sql
@@ -3,9 +3,9 @@ DROP VIEW IF EXISTS camdecmpswks.vw_em_eval_and_submit;
 
 CREATE OR REPLACE VIEW camdecmpswks.vw_em_eval_and_submit AS
 SELECT
-    p.oris_code,
-    p.facility_name,
-    mp.mon_plan_id,
+    fac.oris_code,
+    fac.facility_name,
+    pln.mon_plan_id,
     (
         SELECT
             string_agg(coalesce(unt.unitid, stp.stack_name), ', '::text ORDER BY unt.unitid, stp.stack_name)
@@ -15,29 +15,25 @@ SELECT
             LEFT JOIN camd.unit unt ON unt.unit_id = loc.unit_id
             LEFT JOIN camdecmpswks.stack_pipe stp ON stp.stack_pipe_id = loc.stack_pipe_id
         WHERE
-            mpl.mon_plan_id = mp.mon_plan_id) AS configuration,
-        esc.eval_status_cd,
-        esc.eval_status_cd_description,
-        sac.submission_availability_cd,
-        sac.sub_avail_cd_description AS submission_availability_cd_description,
-        esa.userid,
-        COALESCE(esa.update_date, esa.add_date) AS update_date,
-        esa.sub_availability_cd AS window_status,
-        rpt.period_abbreviation
-    FROM
-        camd.plant p
-        JOIN camdecmpswks.monitor_plan mp ON mp.fac_id = p.fac_id
-        JOIN camdecmpswks.emission_evaluation ee ON ee.mon_plan_id = mp.mon_plan_id
-        JOIN camdecmpsmd.reporting_period rpt ON rpt.rpt_period_id = ee.rpt_period_id
-        JOIN camdecmpsmd.eval_status_code esc ON esc.eval_status_cd::text = ee.eval_status_cd::text
-        JOIN (
-            SELECT
-                ems.mon_plan_id,
-                ems.rpt_period_id,
-                (
-                    SELECT
-                        esa.em_sub_access_id
-                    FROM (
+            mpl.mon_plan_id = pln.mon_plan_id
+    ) AS configuration,
+    esc.eval_status_cd,
+    esc.eval_status_cd_description,
+    sac.submission_availability_cd,
+    sac.sub_avail_cd_description AS submission_availability_cd_description,
+    esa.userid,
+    COALESCE(esa.update_date, esa.add_date) AS update_date,
+    esa.sub_availability_cd AS window_status,
+    prd.period_abbreviation
+FROM (
+        SELECT
+            ems.eval_status_cd,
+            ems.mon_plan_id,
+            ems.rpt_period_id,
+            (
+                SELECT
+                    esa.em_sub_access_id
+                FROM (
                         SELECT
                             sel.mon_plan_id,
                             sel.rpt_period_id,
@@ -49,16 +45,22 @@ SELECT
                             AND sel.rpt_period_id = ems.rpt_period_id
                         GROUP BY
                             sel.mon_plan_id,
-                            sel.rpt_period_id) lst1
-                        JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst1.mon_plan_id
-                            AND esa.rpt_period_id = lst1.rpt_period_id
-                            AND esa.access_begin_date = lst1.last_access_begin_date) AS last_em_sub_access_id
-                    FROM
-                        camdecmpswks.emission_evaluation ems) lst ON lst.mon_plan_id = ee.mon_plan_id
-        AND lst.rpt_period_id = ee.rpt_period_id
+                            sel.rpt_period_id
+                    ) lst1
+                    JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst1.mon_plan_id
+                        AND esa.rpt_period_id = lst1.rpt_period_id
+                        AND esa.access_begin_date = lst1.last_access_begin_date
+            ) AS last_em_sub_access_id
+        FROM
+            camdecmpswks.emission_evaluation ems
+    ) lst
+    JOIN camdecmpsmd.reporting_period prd ON prd.rpt_period_id = lst.rpt_period_id
+    JOIN camdecmpswks.monitor_plan pln ON pln.mon_plan_id = lst.mon_plan_id
+    JOIN camd.plant fac ON fac.fac_id = pln.fac_id
+    JOIN camdecmpsmd.eval_status_code esc ON esc.eval_status_cd::text = lst.eval_status_cd::text
     LEFT JOIN camdecmpsaux.em_submission_access esa ON esa.em_sub_access_id = lst.last_em_sub_access_id
     LEFT JOIN camdecmpsmd.submission_availability_code sac ON sac.submission_availability_cd = esa.sub_availability_cd
 ORDER BY
-    p.oris_code,
+    oris_code,
     configuration,
-    rpt.period_abbreviation;
+    period_abbreviation;

--- a/camdecmpswks/views/vw_em_eval_and_submit.sql
+++ b/camdecmpswks/views/vw_em_eval_and_submit.sql
@@ -3,9 +3,9 @@ DROP VIEW IF EXISTS camdecmpswks.vw_em_eval_and_submit;
 
 CREATE OR REPLACE VIEW camdecmpswks.vw_em_eval_and_submit AS
 SELECT
-    fac.oris_code,
-    fac.facility_name,
-    lst.mon_plan_id,
+    p.oris_code,
+    p.facility_name,
+    mp.mon_plan_id,
     (
         SELECT
             string_agg(coalesce(unt.unitid, stp.stack_name), ', '::text ORDER BY unt.unitid, stp.stack_name)
@@ -15,48 +15,50 @@ SELECT
             LEFT JOIN camd.unit unt ON unt.unit_id = loc.unit_id
             LEFT JOIN camdecmpswks.stack_pipe stp ON stp.stack_pipe_id = loc.stack_pipe_id
         WHERE
-            mpl.mon_plan_id = lst.mon_plan_id) AS configuration,
-        lst.eval_status_cd,
+            mpl.mon_plan_id = mp.mon_plan_id) AS configuration,
+        esc.eval_status_cd,
         esc.eval_status_cd_description,
-        esa.sub_availability_cd AS submission_availability_cd,
+        sac.submission_availability_cd,
         sac.sub_avail_cd_description AS submission_availability_cd_description,
         esa.userid,
         COALESCE(esa.update_date, esa.add_date) AS update_date,
         esa.sub_availability_cd AS window_status,
-        prd.period_abbreviation
-    FROM (
-        SELECT
-            ems.mon_plan_id,
-            ems.rpt_period_id,
-            ems.eval_status_cd,
-            (
-                SELECT
-                    esa.em_sub_access_id
-                FROM (
+        rpt.period_abbreviation
+    FROM
+        camd.plant p
+        JOIN camdecmpswks.monitor_plan mp ON mp.fac_id = p.fac_id
+        JOIN camdecmpswks.emission_evaluation ee ON ee.mon_plan_id = mp.mon_plan_id
+        JOIN camdecmpsmd.reporting_period rpt ON rpt.rpt_period_id = ee.rpt_period_id
+        JOIN camdecmpsmd.eval_status_code esc ON esc.eval_status_cd::text = ee.eval_status_cd::text
+        JOIN (
+            SELECT
+                ems.mon_plan_id,
+                ems.rpt_period_id,
+                (
                     SELECT
-                        sel.mon_plan_id,
-                        sel.rpt_period_id,
-                        max(sel.access_begin_date) AS last_access_begin_date
+                        esa.em_sub_access_id
+                    FROM (
+                        SELECT
+                            sel.mon_plan_id,
+                            sel.rpt_period_id,
+                            max(sel.access_begin_date) AS last_access_begin_date
+                        FROM
+                            camdecmpsaux.em_submission_access sel
+                        WHERE
+                            sel.mon_plan_id = ems.mon_plan_id
+                            AND sel.rpt_period_id = ems.rpt_period_id
+                        GROUP BY
+                            sel.mon_plan_id,
+                            sel.rpt_period_id) lst1
+                        JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst1.mon_plan_id
+                            AND esa.rpt_period_id = lst1.rpt_period_id
+                            AND esa.access_begin_date = lst1.last_access_begin_date) AS last_em_sub_access_id
                     FROM
-                        camdecmpsaux.em_submission_access sel
-                    WHERE
-                        sel.mon_plan_id = ems.mon_plan_id
-                        AND sel.rpt_period_id = ems.rpt_period_id
-                    GROUP BY
-                        sel.mon_plan_id,
-                        sel.rpt_period_id) lst
-                    JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst.mon_plan_id
-                        AND esa.rpt_period_id = lst.rpt_period_id
-                        AND esa.access_begin_date = lst.last_access_begin_date) AS last_em_sub_access_id
-                FROM
-                    camdecmpswks.emission_evaluation ems) lst
-JOIN camdecmpsaux.em_submission_access esa ON esa.em_sub_access_id = lst.last_em_sub_access_id
-JOIN camdecmpsmd.reporting_period prd ON prd.rpt_period_id = lst.rpt_period_id
-JOIN camdecmpswks.monitor_plan pln ON pln.mon_plan_id = lst.mon_plan_id
-JOIN camd.plant fac ON fac.fac_id = pln.fac_id
-JOIN camdecmpsmd.submission_availability_code sac ON sac.submission_availability_cd::text = esa.sub_availability_cd::text
-JOIN camdecmpsmd.eval_status_code esc ON esc.eval_status_cd::text = lst.eval_status_cd::text
+                        camdecmpswks.emission_evaluation ems) lst ON lst.mon_plan_id = ee.mon_plan_id
+        AND lst.rpt_period_id = ee.rpt_period_id
+    LEFT JOIN camdecmpsaux.em_submission_access esa ON esa.em_sub_access_id = lst.last_em_sub_access_id
+    LEFT JOIN camdecmpsmd.submission_availability_code sac ON sac.submission_availability_cd = esa.sub_availability_cd
 ORDER BY
-    oris_code,
+    p.oris_code,
     configuration,
-    period_abbreviation;
+    rpt.period_abbreviation;

--- a/deployments/ecmps/release-v2.0-fix/6068/camdecmps/vw_em_eval_and_submit.sql
+++ b/deployments/ecmps/release-v2.0-fix/6068/camdecmps/vw_em_eval_and_submit.sql
@@ -1,8 +1,8 @@
 CREATE OR REPLACE VIEW camdecmps.vw_em_eval_and_submit AS
 SELECT
-    p.oris_code,
-    p.facility_name,
-    mp.mon_plan_id,
+    fac.oris_code,
+    fac.facility_name,
+    pln.mon_plan_id,
     (
         SELECT
             string_agg(coalesce(unt.unitid, stp.stack_name), ', '::text ORDER BY unt.unitid, stp.stack_name)
@@ -12,24 +12,20 @@ SELECT
             LEFT JOIN camd.unit unt ON unt.unit_id = loc.unit_id
             LEFT JOIN camdecmps.stack_pipe stp ON stp.stack_pipe_id = loc.stack_pipe_id
         WHERE
-            mpl.mon_plan_id = lst.mon_plan_id) AS configuration,
-        esa.userid,
-        COALESCE(esa.update_date, esa.add_date) AS update_date,
-        esa.sub_availability_cd AS window_status,
-        rpt.period_abbreviation
-    FROM
-        camd.plant p
-        JOIN camdecmps.monitor_plan mp ON mp.fac_id = p.fac_id
-        JOIN camdecmps.emission_evaluation ee ON ee.mon_plan_id = mp.mon_plan_id
-        JOIN camdecmpsmd.reporting_period rpt ON rpt.rpt_period_id = ee.rpt_period_id
-        JOIN (
-            SELECT
-                ems.mon_plan_id,
-                ems.rpt_period_id,
-                (
-                    SELECT
-                        esa.em_sub_access_id
-                    FROM (
+            mpl.mon_plan_id = lst.mon_plan_id
+    ) AS configuration,
+    esa.userid,
+    COALESCE(esa.update_date, esa.add_date) AS update_date,
+    esa.sub_availability_cd AS window_status,
+    prd.period_abbreviation
+FROM (
+        SELECT
+            ems.mon_plan_id,
+            ems.rpt_period_id,
+            (
+                SELECT
+                    esa.em_sub_access_id
+                FROM (
                         SELECT
                             sel.mon_plan_id,
                             sel.rpt_period_id,
@@ -41,15 +37,20 @@ SELECT
                             AND sel.rpt_period_id = ems.rpt_period_id
                         GROUP BY
                             sel.mon_plan_id,
-                            sel.rpt_period_id) lst1
-                        JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst1.mon_plan_id
-                            AND esa.rpt_period_id = lst1.rpt_period_id
-                            AND esa.access_begin_date = lst1.last_access_begin_date) AS last_em_sub_access_id
-                    FROM
-                        camdecmps.emission_evaluation ems) lst ON lst.mon_plan_id = ee.mon_plan_id
-        AND lst.rpt_period_id = ee.rpt_period_id
+                            sel.rpt_period_id
+                    ) lst1
+                    JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst1.mon_plan_id
+                        AND esa.rpt_period_id = lst1.rpt_period_id
+                        AND esa.access_begin_date = lst1.last_access_begin_date
+            ) AS last_em_sub_access_id
+        FROM
+            camdecmps.emission_evaluation ems
+    ) lst
+    JOIN camdecmpsmd.reporting_period prd ON prd.rpt_period_id = lst.rpt_period_id
+    JOIN camdecmps.monitor_plan pln ON pln.mon_plan_id = lst.mon_plan_id
+    JOIN camd.plant fac ON fac.fac_id = pln.fac_id
     LEFT JOIN camdecmpsaux.em_submission_access esa ON esa.em_sub_access_id = lst.last_em_sub_access_id
 ORDER BY
-    p.oris_code,
+    oris_code,
     configuration,
-    rpt.period_abbreviation;
+    period_abbreviation;

--- a/deployments/ecmps/release-v2.0-fix/6068/camdecmps/vw_em_eval_and_submit.sql
+++ b/deployments/ecmps/release-v2.0-fix/6068/camdecmps/vw_em_eval_and_submit.sql
@@ -1,8 +1,8 @@
 CREATE OR REPLACE VIEW camdecmps.vw_em_eval_and_submit AS
 SELECT
-    fac.oris_code,
-    fac.facility_name,
-    lst.mon_plan_id,
+    p.oris_code,
+    p.facility_name,
+    mp.mon_plan_id,
     (
         SELECT
             string_agg(coalesce(unt.unitid, stp.stack_name), ', '::text ORDER BY unt.unitid, stp.stack_name)
@@ -16,37 +16,40 @@ SELECT
         esa.userid,
         COALESCE(esa.update_date, esa.add_date) AS update_date,
         esa.sub_availability_cd AS window_status,
-        prd.period_abbreviation
-    FROM (
-        SELECT
-            ems.mon_plan_id,
-            ems.rpt_period_id,
-            (
-                SELECT
-                    esa.em_sub_access_id
-                FROM (
+        rpt.period_abbreviation
+    FROM
+        camd.plant p
+        JOIN camdecmps.monitor_plan mp ON mp.fac_id = p.fac_id
+        JOIN camdecmps.emission_evaluation ee ON ee.mon_plan_id = mp.mon_plan_id
+        JOIN camdecmpsmd.reporting_period rpt ON rpt.rpt_period_id = ee.rpt_period_id
+        JOIN (
+            SELECT
+                ems.mon_plan_id,
+                ems.rpt_period_id,
+                (
                     SELECT
-                        sel.mon_plan_id,
-                        sel.rpt_period_id,
-                        max(sel.access_begin_date) AS last_access_begin_date
+                        esa.em_sub_access_id
+                    FROM (
+                        SELECT
+                            sel.mon_plan_id,
+                            sel.rpt_period_id,
+                            max(sel.access_begin_date) AS last_access_begin_date
+                        FROM
+                            camdecmpsaux.em_submission_access sel
+                        WHERE
+                            sel.mon_plan_id = ems.mon_plan_id
+                            AND sel.rpt_period_id = ems.rpt_period_id
+                        GROUP BY
+                            sel.mon_plan_id,
+                            sel.rpt_period_id) lst1
+                        JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst1.mon_plan_id
+                            AND esa.rpt_period_id = lst1.rpt_period_id
+                            AND esa.access_begin_date = lst1.last_access_begin_date) AS last_em_sub_access_id
                     FROM
-                        camdecmpsaux.em_submission_access sel
-                    WHERE
-                        sel.mon_plan_id = ems.mon_plan_id
-                        AND sel.rpt_period_id = ems.rpt_period_id
-                    GROUP BY
-                        sel.mon_plan_id,
-                        sel.rpt_period_id) lst
-                    JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst.mon_plan_id
-                        AND esa.rpt_period_id = lst.rpt_period_id
-                        AND esa.access_begin_date = lst.last_access_begin_date) AS last_em_sub_access_id
-                FROM
-                    camdecmps.emission_evaluation ems) lst
-JOIN camdecmpsaux.em_submission_access esa ON esa.em_sub_access_id = lst.last_em_sub_access_id
-JOIN camdecmpsmd.reporting_period prd ON prd.rpt_period_id = lst.rpt_period_id
-JOIN camdecmps.monitor_plan pln ON pln.mon_plan_id = lst.mon_plan_id
-JOIN camd.plant fac ON fac.fac_id = pln.fac_id
+                        camdecmps.emission_evaluation ems) lst ON lst.mon_plan_id = ee.mon_plan_id
+        AND lst.rpt_period_id = ee.rpt_period_id
+    LEFT JOIN camdecmpsaux.em_submission_access esa ON esa.em_sub_access_id = lst.last_em_sub_access_id
 ORDER BY
-    oris_code,
+    p.oris_code,
     configuration,
-    period_abbreviation;
+    rpt.period_abbreviation;

--- a/deployments/ecmps/release-v2.0-fix/6068/camdecmpswks/vw_em_eval_and_submit.sql
+++ b/deployments/ecmps/release-v2.0-fix/6068/camdecmpswks/vw_em_eval_and_submit.sql
@@ -3,9 +3,9 @@ DROP VIEW IF EXISTS camdecmpswks.vw_em_eval_and_submit;
 
 CREATE OR REPLACE VIEW camdecmpswks.vw_em_eval_and_submit AS
 SELECT
-    p.oris_code,
-    p.facility_name,
-    mp.mon_plan_id,
+    fac.oris_code,
+    fac.facility_name,
+    pln.mon_plan_id,
     (
         SELECT
             string_agg(coalesce(unt.unitid, stp.stack_name), ', '::text ORDER BY unt.unitid, stp.stack_name)
@@ -15,29 +15,25 @@ SELECT
             LEFT JOIN camd.unit unt ON unt.unit_id = loc.unit_id
             LEFT JOIN camdecmpswks.stack_pipe stp ON stp.stack_pipe_id = loc.stack_pipe_id
         WHERE
-            mpl.mon_plan_id = mp.mon_plan_id) AS configuration,
-        esc.eval_status_cd,
-        esc.eval_status_cd_description,
-        sac.submission_availability_cd,
-        sac.sub_avail_cd_description AS submission_availability_cd_description,
-        esa.userid,
-        COALESCE(esa.update_date, esa.add_date) AS update_date,
-        esa.sub_availability_cd AS window_status,
-        rpt.period_abbreviation
-    FROM
-        camd.plant p
-        JOIN camdecmpswks.monitor_plan mp ON mp.fac_id = p.fac_id
-        JOIN camdecmpswks.emission_evaluation ee ON ee.mon_plan_id = mp.mon_plan_id
-        JOIN camdecmpsmd.reporting_period rpt ON rpt.rpt_period_id = ee.rpt_period_id
-        JOIN camdecmpsmd.eval_status_code esc ON esc.eval_status_cd::text = ee.eval_status_cd::text
-        JOIN (
-            SELECT
-                ems.mon_plan_id,
-                ems.rpt_period_id,
-                (
-                    SELECT
-                        esa.em_sub_access_id
-                    FROM (
+            mpl.mon_plan_id = pln.mon_plan_id
+    ) AS configuration,
+    esc.eval_status_cd,
+    esc.eval_status_cd_description,
+    sac.submission_availability_cd,
+    sac.sub_avail_cd_description AS submission_availability_cd_description,
+    esa.userid,
+    COALESCE(esa.update_date, esa.add_date) AS update_date,
+    esa.sub_availability_cd AS window_status,
+    prd.period_abbreviation
+FROM (
+        SELECT
+            ems.eval_status_cd,
+            ems.mon_plan_id,
+            ems.rpt_period_id,
+            (
+                SELECT
+                    esa.em_sub_access_id
+                FROM (
                         SELECT
                             sel.mon_plan_id,
                             sel.rpt_period_id,
@@ -49,16 +45,22 @@ SELECT
                             AND sel.rpt_period_id = ems.rpt_period_id
                         GROUP BY
                             sel.mon_plan_id,
-                            sel.rpt_period_id) lst1
-                        JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst1.mon_plan_id
-                            AND esa.rpt_period_id = lst1.rpt_period_id
-                            AND esa.access_begin_date = lst1.last_access_begin_date) AS last_em_sub_access_id
-                    FROM
-                        camdecmpswks.emission_evaluation ems) lst ON lst.mon_plan_id = ee.mon_plan_id
-        AND lst.rpt_period_id = ee.rpt_period_id
+                            sel.rpt_period_id
+                    ) lst1
+                    JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst1.mon_plan_id
+                        AND esa.rpt_period_id = lst1.rpt_period_id
+                        AND esa.access_begin_date = lst1.last_access_begin_date
+            ) AS last_em_sub_access_id
+        FROM
+            camdecmpswks.emission_evaluation ems
+    ) lst
+    JOIN camdecmpsmd.reporting_period prd ON prd.rpt_period_id = lst.rpt_period_id
+    JOIN camdecmpswks.monitor_plan pln ON pln.mon_plan_id = lst.mon_plan_id
+    JOIN camd.plant fac ON fac.fac_id = pln.fac_id
+    JOIN camdecmpsmd.eval_status_code esc ON esc.eval_status_cd::text = lst.eval_status_cd::text
     LEFT JOIN camdecmpsaux.em_submission_access esa ON esa.em_sub_access_id = lst.last_em_sub_access_id
     LEFT JOIN camdecmpsmd.submission_availability_code sac ON sac.submission_availability_cd = esa.sub_availability_cd
 ORDER BY
-    p.oris_code,
+    oris_code,
     configuration,
-    rpt.period_abbreviation;
+    period_abbreviation;

--- a/deployments/ecmps/release-v2.0-fix/6068/camdecmpswks/vw_em_eval_and_submit.sql
+++ b/deployments/ecmps/release-v2.0-fix/6068/camdecmpswks/vw_em_eval_and_submit.sql
@@ -3,9 +3,9 @@ DROP VIEW IF EXISTS camdecmpswks.vw_em_eval_and_submit;
 
 CREATE OR REPLACE VIEW camdecmpswks.vw_em_eval_and_submit AS
 SELECT
-    fac.oris_code,
-    fac.facility_name,
-    lst.mon_plan_id,
+    p.oris_code,
+    p.facility_name,
+    mp.mon_plan_id,
     (
         SELECT
             string_agg(coalesce(unt.unitid, stp.stack_name), ', '::text ORDER BY unt.unitid, stp.stack_name)
@@ -15,48 +15,50 @@ SELECT
             LEFT JOIN camd.unit unt ON unt.unit_id = loc.unit_id
             LEFT JOIN camdecmpswks.stack_pipe stp ON stp.stack_pipe_id = loc.stack_pipe_id
         WHERE
-            mpl.mon_plan_id = lst.mon_plan_id) AS configuration,
-        lst.eval_status_cd,
+            mpl.mon_plan_id = mp.mon_plan_id) AS configuration,
+        esc.eval_status_cd,
         esc.eval_status_cd_description,
-        esa.sub_availability_cd AS submission_availability_cd,
+        sac.submission_availability_cd,
         sac.sub_avail_cd_description AS submission_availability_cd_description,
         esa.userid,
         COALESCE(esa.update_date, esa.add_date) AS update_date,
         esa.sub_availability_cd AS window_status,
-        prd.period_abbreviation
-    FROM (
-        SELECT
-            ems.mon_plan_id,
-            ems.rpt_period_id,
-            ems.eval_status_cd,
-            (
-                SELECT
-                    esa.em_sub_access_id
-                FROM (
+        rpt.period_abbreviation
+    FROM
+        camd.plant p
+        JOIN camdecmpswks.monitor_plan mp ON mp.fac_id = p.fac_id
+        JOIN camdecmpswks.emission_evaluation ee ON ee.mon_plan_id = mp.mon_plan_id
+        JOIN camdecmpsmd.reporting_period rpt ON rpt.rpt_period_id = ee.rpt_period_id
+        JOIN camdecmpsmd.eval_status_code esc ON esc.eval_status_cd::text = ee.eval_status_cd::text
+        JOIN (
+            SELECT
+                ems.mon_plan_id,
+                ems.rpt_period_id,
+                (
                     SELECT
-                        sel.mon_plan_id,
-                        sel.rpt_period_id,
-                        max(sel.access_begin_date) AS last_access_begin_date
+                        esa.em_sub_access_id
+                    FROM (
+                        SELECT
+                            sel.mon_plan_id,
+                            sel.rpt_period_id,
+                            max(sel.access_begin_date) AS last_access_begin_date
+                        FROM
+                            camdecmpsaux.em_submission_access sel
+                        WHERE
+                            sel.mon_plan_id = ems.mon_plan_id
+                            AND sel.rpt_period_id = ems.rpt_period_id
+                        GROUP BY
+                            sel.mon_plan_id,
+                            sel.rpt_period_id) lst1
+                        JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst1.mon_plan_id
+                            AND esa.rpt_period_id = lst1.rpt_period_id
+                            AND esa.access_begin_date = lst1.last_access_begin_date) AS last_em_sub_access_id
                     FROM
-                        camdecmpsaux.em_submission_access sel
-                    WHERE
-                        sel.mon_plan_id = ems.mon_plan_id
-                        AND sel.rpt_period_id = ems.rpt_period_id
-                    GROUP BY
-                        sel.mon_plan_id,
-                        sel.rpt_period_id) lst
-                    JOIN camdecmpsaux.EM_SUBMISSION_ACCESS esa ON esa.mon_plan_id = lst.mon_plan_id
-                        AND esa.rpt_period_id = lst.rpt_period_id
-                        AND esa.access_begin_date = lst.last_access_begin_date) AS last_em_sub_access_id
-                FROM
-                    camdecmpswks.emission_evaluation ems) lst
-JOIN camdecmpsaux.em_submission_access esa ON esa.em_sub_access_id = lst.last_em_sub_access_id
-JOIN camdecmpsmd.reporting_period prd ON prd.rpt_period_id = lst.rpt_period_id
-JOIN camdecmpswks.monitor_plan pln ON pln.mon_plan_id = lst.mon_plan_id
-JOIN camd.plant fac ON fac.fac_id = pln.fac_id
-JOIN camdecmpsmd.submission_availability_code sac ON sac.submission_availability_cd::text = esa.sub_availability_cd::text
-JOIN camdecmpsmd.eval_status_code esc ON esc.eval_status_cd::text = lst.eval_status_cd::text
+                        camdecmpswks.emission_evaluation ems) lst ON lst.mon_plan_id = ee.mon_plan_id
+        AND lst.rpt_period_id = ee.rpt_period_id
+    LEFT JOIN camdecmpsaux.em_submission_access esa ON esa.em_sub_access_id = lst.last_em_sub_access_id
+    LEFT JOIN camdecmpsmd.submission_availability_code sac ON sac.submission_availability_cd = esa.sub_availability_cd
 ORDER BY
-    oris_code,
+    p.oris_code,
     configuration,
-    period_abbreviation;
+    rpt.period_abbreviation;


### PR DESCRIPTION
## Main Changes:

- Updated the `vw_em_eval_and_submit` views to include evaluations without submissions.
  - The submission codes still pull from the latest submission, but evaluations without submissions are included with empty fields for the submission data.

## Steps to Test:

1. Run the workspace query that is currently in place against the Dev database, and save or note the output.
2. Run the updated query against the Dev database (**starting with `SELECT`**), and note the output. There should be more rows in the output of the updated query, but the additional rows should have null values for `submission_availability_cd`, `submission_availability_cd_description`, `user_id`, `update_date`, and `window_status`.
3. Compare the row count of the `camdecmps.vw_em_eval_and_submit` query with the view that was in place when this issue was raised. This is the count query for the original view:
```
SELECT
    count(*)
FROM (
    SELECT
        p.oris_code,
        p.facility_name,
        d.mon_plan_id,
        d.configuration,
        esa.userid,
        esa.update_date AS update_date,
        esa.window_status AS window_status,
        rpt.period_abbreviation
    FROM
        camd.plant p
        JOIN camdecmps.monitor_plan mp USING (fac_id)
        JOIN (
            SELECT
                mon_plan_id, string_agg(unit_stack, ', ') AS configuration
            FROM (
                SELECT
                    mon_plan_id,
                    COALESCE(unitid, stack_name) AS unit_stack
                FROM
                    camdecmps.monitor_plan_location mpl
                    JOIN camdecmps.monitor_location ml USING (mon_loc_id)
                    LEFT JOIN camdecmps.stack_pipe USING (stack_pipe_id)
                    LEFT JOIN camd.unit USING (unit_id)
                ORDER BY
                    mon_plan_id, unitid, stack_name) AS d1
            GROUP BY
                mon_plan_id) AS d USING (mon_plan_id)
JOIN camdecmps.emission_evaluation ee USING (mon_plan_id)
JOIN camdecmpsmd.reporting_period rpt ON ee.rpt_period_id = rpt.rpt_period_id
    LEFT JOIN ( SELECT DISTINCT ON (esa.mon_plan_id, esa.rpt_period_id)
            esa.mon_plan_id, esa.rpt_period_id, esa.userid, COALESCE(esa.update_date, esa.add_date) AS update_date,
            esa.sub_availability_cd AS window_status
        FROM
            camdecmpsaux.em_submission_access esa
        WHERE
            esa.em_status_cd::text <> 'RECVD'::text
        ORDER BY
            esa.mon_plan_id,
            esa.rpt_period_id,
            esa.access_begin_date DESC) esa ON ee.mon_plan_id::text = esa.mon_plan_id::text
        AND ee.rpt_period_id = esa.rpt_period_id
    ORDER BY
        p.oris_code,
        configuration,
        rpt.period_abbreviation) AS foo;
```

## TODO:

- [x] Look into the UI and check if the output needs to be adjusted to account for empty submission windows. @esaber76 noted that in 1.0, if the window isn't open yet it displays something similar to "No Submission Window".