### PR TITLE
Feature/5576 process inventory changes

### DIFF
--- a/camdecmpswks/procedures/update_mp_eval_status_and_reporting_freq.sql
+++ b/camdecmpswks/procedures/update_mp_eval_status_and_reporting_freq.sql
@@ -74,7 +74,7 @@ BEGIN
                         JOIN camd.UNIT_PROGRAM AS UP USING(UNIT_ID)
                         JOIN camdmd.PROGRAM_CODE AS PC USING(PRG_CD)
                     WHERE 
-                        AND PC.OS_IND <> 1
+                        PC.OS_IND <> 1
                         AND UP.UNIT_ID = par_V_UNIT_ID 
                         AND MP.END_RPT_PERIOD_ID IS NULL
                 ) AS UMCBD ON MPRF.MON_PLAN_ID = UMCBD.MON_PLAN_ID

--- a/deployments/ecmps/release-v2.0-fix/Sprint11/5576/camdecmpswks/update_mp_eval_status_and_reporting_freq.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint11/5576/camdecmpswks/update_mp_eval_status_and_reporting_freq.sql
@@ -1,6 +1,6 @@
 -- PROCEDURE: camdecmpswks.update_mp_eval_status_and_reporting_freq(numeric, character varying)
 
-DROP PROCEDURE IF EXISTS camdecmpswks.update_mp_eval_status_and_reporting_freq(numeric, character varying);
+DROP PROCEDURE IF EXISTS camdecmpswks.update_mp_eval_status_and_reporting_freq();
 
 CREATE OR REPLACE PROCEDURE camdecmpswks.update_mp_eval_status_and_reporting_freq(
     par_V_UNIT_ID numeric,

--- a/deployments/ecmps/release-v2.0-fix/Sprint11/5576/camdecmpswks/update_mp_eval_status_and_reporting_freq.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint11/5576/camdecmpswks/update_mp_eval_status_and_reporting_freq.sql
@@ -74,7 +74,7 @@ BEGIN
                         JOIN camd.UNIT_PROGRAM AS UP USING(UNIT_ID)
                         JOIN camdmd.PROGRAM_CODE AS PC USING(PRG_CD)
                     WHERE 
-                        AND PC.OS_IND <> 1
+                        PC.OS_IND <> 1
                         AND UP.UNIT_ID = par_V_UNIT_ID 
                         AND MP.END_RPT_PERIOD_ID IS NULL
                 ) AS UMCBD ON MPRF.MON_PLAN_ID = UMCBD.MON_PLAN_ID


### PR DESCRIPTION
## Related Issues:

- [#5576](https://github.com/US-EPA-CAMD/easey-ui/issues/5576)

## Main Changes:

- Updated the _camdecmpswks.update_mp_eval_status_and_reporting_freq_ procedure to take two parameters as input (`par_V_UNIT_ID` and `par_V_DATA_TYPE_CD`), instead of processing _all_ units with rows in the _inventory_status_log_ table.
  - Monitoring plan reporting frequencies are updated only if the data type code is `UNIT_PROGRAM`, but MP evaluation statuses are reset for all plans associated with the unit parameter, regardless of data type code.