### PR TITLE
Feature/6375 evaluation queue additional fields

### DIFF
--- a/camdecmpsaux/tables/evaluation_queue.sql
+++ b/camdecmpsaux/tables/evaluation_queue.sql
@@ -8,7 +8,11 @@ CREATE TABLE IF NOT EXISTS camdecmpsaux.evaluation_queue
     test_extension_exemption_id character varying(45) COLLATE pg_catalog."default",
     rpt_period_id numeric(38,0),
     eval_status_cd character varying(8) COLLATE pg_catalog."default",
-    submitted_on timestamp without time zone NOT NULL,
+    queued_time timestamp without time zone NOT NULL,
     status_cd character varying(8) COLLATE pg_catalog."default" NOT NULL,
-    details text COLLATE pg_catalog."default"
+    details text COLLATE pg_catalog."default",
+    started_time timestamp without time zone,
+    completed_time timestamp without time zone,
+    note character varying(1000) COLLATE pg_catalog."default",
+    note_time timestamp without time zone
 );

--- a/deployments/ecmps/release-v2.0-fix/Sprint11/6375/camdecmpsaux/evaluation_queue.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint11/6375/camdecmpsaux/evaluation_queue.sql
@@ -1,0 +1,14 @@
+ALTER TABLE camdecmpsaux.evaluation_queue RENAME COLUMN submitted_on TO queued_time;
+
+ALTER TABLE camdecmpsaux.evaluation_queue
+    ADD COLUMN IF NOT EXISTS started_time timestamp WITHOUT time zone;
+
+ALTER TABLE camdecmpsaux.evaluation_queue
+    ADD COLUMN IF NOT EXISTS completed_time timestamp WITHOUT time zone;
+
+ALTER TABLE camdecmpsaux.evaluation_queue
+    ADD COLUMN IF NOT EXISTS note character varying(1000) COLLATE pg_catalog."default";
+
+ALTER TABLE camdecmpsaux.evaluation_queue
+    ADD COLUMN IF NOT EXISTS note_time timestamp WITHOUT time zone;
+


### PR DESCRIPTION
## Related Issues:

- [#6375](https://github.com/US-EPA-CAMD/easey-ui/issues/6375)

## Main Changes:

- Updated the `camdecmpsaux.evaluation_queue` table: renamed 1 column and added 4 columns.
- Added a migration script to alter the table.