### PR TITLE
Updated camdaux.datacolumn misspelling alias and display_name of Exceedance

### DIFF
--- a/deployments/ecmps/release-v2.0-fix/Sprint15/6441/load-emission-view-dailybackstop.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint15/6441/load-emission-view-dailybackstop.sql
@@ -1,0 +1,41 @@
+DO $$
+DECLARE
+	datasetCode text := 'DAILYBACKSTOP';
+	groupCode text := 'EMVIEW';
+	datatableId integer;
+BEGIN
+	DELETE FROM camdaux.dataset WHERE dataset_cd = datasetCode;
+
+	INSERT INTO camdaux.dataset(dataset_cd, group_cd, display_name, sort_order, no_results_msg)
+	VALUES(datasetCode, groupCode, 'Daily Backstop View', 23, 'Daily Backstop data does not exist for the specified monitor plan and reporting period.');
+
+ -- Delete existing columns for the datatable with the dataset_cd 'DAILYBACKSTOP'
+   DELETE FROM camdaux.datacolumn
+    WHERE datatable_id = (
+    SELECT datatable_id
+    FROM camdaux.datatable
+    WHERE dataset_cd = datasetCode
+    )
+    AND column_order IN (1, 2, 3, 4, 5, 6, 7);
+
+    -- Delete existing datatable for the given dataset_code
+    DELETE FROM camdaux.datatable WHERE dataset_cd = datasetCode;
+
+    -- Insert new row into camdaux.datatable
+    /***** DATATABLE 1 *****/
+    INSERT INTO camdaux.datatable(dataset_cd, table_order, display_name, sql_statement, no_results_msg_override)
+    VALUES(datasetCode, 1, 'Daily Backstop View', null, null)
+    RETURNING datatable_id INTO datatableId;
+
+    -- Insert new columns for the datatable
+    /***** COLUMNS *****/
+    INSERT INTO camdaux.datacolumn(datatable_id, column_order, name, alias, display_name)
+    VALUES
+        (datatableId, 1, 'unit_name', 'unitName', 'Unit'),
+        (datatableId, 2, 'op_date', 'opDate', 'Op. Date'),
+        (datatableId, 3, 'daily_noxm', 'dailyNOXMass', 'Daily NOx Mass Rate (lb/hr)'),
+        (datatableId, 4, 'daily_hit', 'daily_hit', 'Daily Heat Input'),
+        (datatableId, 5, 'daily_avg_noxr', 'dailyAvgNOXRate', 'Daily Avg. NOx Rate (lb/mmBtu)'),
+        (datatableId, 6, 'daily_noxm_exceed', 'dailyNOXMassExceedance', 'Daily NOx Mass Exceedance'),
+        (datatableId, 7, 'cumulative_os_noxm_exceed', 'cumulativeNOXMassExceedance', 'Cumulative NOx Mass Exceedance');
+END $$;

--- a/deployments/ecmps/release-v2.0/emissions-view-definitions/load-emission-view-dailybackstop.sql
+++ b/deployments/ecmps/release-v2.0/emissions-view-definitions/load-emission-view-dailybackstop.sql
@@ -22,6 +22,6 @@ BEGIN
 		(datatableId, 3, 'daily_noxm', 'dailyNOXMass', 'Daily NOx Mass Rate (lb/hr)'),
 		(datatableId, 4, 'daily_hit', 'daily_hit', 'Daily Heat Input'),
 		(datatableId, 5, 'daily_avg_noxr', 'dailyAvgNOXRate', 'Daily Avg. NOx Rate (lb/mmBtu)'),
-		(datatableId, 6, 'daily_noxm_exceed', 'dailyNOXMassExceedence', 'Daily NOx Mass Exceedence'),
-		(datatableId, 7, 'cumulative_os_noxm_exceed', 'cumulativeNOXMassExceedence', 'Cumulative NOx Mass Exceedence');
+		(datatableId, 6, 'daily_noxm_exceed', 'dailyNOXMassExceedance', 'Daily NOx Mass Exceedance'),
+		(datatableId, 7, 'cumulative_os_noxm_exceed', 'cumulativeNOXMassExceedance', 'Cumulative NOx Mass Exceedance');
 END $$;


### PR DESCRIPTION
Related Tickets:
https://github.com/US-EPA-CAMD/easey-ui/issues/6488

Updates:
Updated camdaux.datacolumn misspelling alias and display_name of Exceedance. 
Created deploy folder and added file in there as well. 
