### PR TITLE
#6067 Changed Return to Return-Next to correctly handle table return …

### DIFF
--- a/camdecmpswks/functions/delete_calculated_em_data_from_workspace.sql
+++ b/camdecmpswks/functions/delete_calculated_em_data_from_workspace.sql
@@ -19,7 +19,7 @@ BEGIN
     error_msg := '';
     result := 'T';	 
 
-	 create temp table tmpMonInfo(MON_PLAN_ID character varying,
+	create temp table tmpMonInfo(MON_PLAN_ID character varying,
 	          MON_LOC_ID character varying, RPT_PERIOD_ID int);
 	
          ----- Get the MON_LOC_IDs for this MP
@@ -127,13 +127,13 @@ BEGIN
 	 select * into result, error_msg 
 	   from camdecmpswks.emissions_grid_remove_eval(vmonplan_id, vrptperiod_id );	
 	
-	 return;
+	RETURN NEXT; -- Add row to return table.
 
 exception when others then
     get stacked diagnostics error_msg := message_text;
     result = 'F'; 
 	error_msg :='From delete_calculated_em_data_from_workspace '||' '|| message_text;
 	
-   return;
+    RETURN NEXT; -- Add row to return table.
 END;
 $BODY$;

--- a/camdecmpswks/functions/emissions_grid_remove_eval.sql
+++ b/camdecmpswks/functions/emissions_grid_remove_eval.sql
@@ -164,13 +164,13 @@ BEGIN
 		where MON_PLAN_ID =vmonplan_id
 		  and RPT_PERIOD_ID = vrptperiod_id;
 
- return;
+    RETURN NEXT; -- Add row to return table.
 
 exception when others then
     get stacked diagnostics error_msg := message_text;
     result = 'F';  
 	error_msg :='From emissions_grid_remove_eval '||' '|| message_text;
 	
-   return;
+    RETURN NEXT; -- Add row to return table.
 END;
 $BODY$;

--- a/camdecmpswks/functions/update_ecmps_status_for_em_evaluation.sql
+++ b/camdecmpswks/functions/update_ecmps_status_for_em_evaluation.sql
@@ -28,9 +28,9 @@ begin
 
 	select  coalesce ( max( 'Y' ), 'N' ) as Submittable
       into  vSubmittable
-      from  camdecmpswks.EM_SUBMISSION_ACCESS
+      from  camdecmpsaux.EM_SUBMISSION_ACCESS
      where  mon_plan_id = vmon_plan_id
-       and  SUBMISSION_AVAILABILITY_CD IN ('GRANTED', 'REQUIRE')
+       and  sub_availability_cd IN ('GRANTED', 'REQUIRE')
 	   and  RPT_PERIOD_ID = vperiod_id;
 	   
  	-- delete old evaluation data from check logs	  
@@ -55,23 +55,24 @@ begin
 	CALL camdecmpswks.refresh_emissions_views(vmon_plan_id,vYear, vQuarter);	
 
 	-- Update Monitoring Plan Needs Evaluation, if needed
-      UPDATE  camdecmpswks.MONITOR_PLAN
-           SET NEEDS_EVAL_FLG = 'Y',
-               CHK_SESSION_ID = null
-        WHERE MON_PLAN_ID = vmon_plan_id
-          AND  EXISTS
-              ( SELECT  1
-                   FROM  camdecmpswks.CHECK_LOG chl
-                    JOIN camdecmpsmd.CHECK_CATALOG_RESULT ccr ON ccr.CHECK_CATALOG_RESULT_ID = chl.CHECK_CATALOG_RESULT_ID
-                    JOIN camdecmpsmd.CHECK_CATALOG chk ON chk.CHECK_CATALOG_ID = ccr.CHECK_CATALOG_ID
-                     WHERE  chl.CHK_SESSION_ID = vchk_session_id
-                       AND  chk.CHECK_TYPE_CD = 'HOURGEN'
-                       AND  chk.CHECK_NUMBER = 8
-                       AND  ccr.CHECK_RESULT = 'C'
-                );	
+    UPDATE  camdecmpswks.MONITOR_PLAN
+       SET NEEDS_EVAL_FLG = 'Y',
+           CHK_SESSION_ID = null
+     WHERE MON_PLAN_ID = vmon_plan_id
+       AND EXISTS
+           ( SELECT  1
+               FROM  camdecmpswks.CHECK_LOG chl
+                     JOIN camdecmpsmd.CHECK_CATALOG_RESULT ccr ON ccr.CHECK_CATALOG_RESULT_ID = chl.CHECK_CATALOG_RESULT_ID
+                     JOIN camdecmpsmd.CHECK_CATALOG chk ON chk.CHECK_CATALOG_ID = ccr.CHECK_CATALOG_ID
+              WHERE  chl.CHK_SESSION_ID = vchk_session_id
+                AND  chk.CHECK_TYPE_CD = 'HOURGEN'
+                AND  chk.CHECK_NUMBER = 8
+                AND  ccr.CHECK_RESULT = 'C'
+           );	
  
-   if vSubmittable = 'Y' then  
-     create temp table tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+    if vSubmittable = 'Y' then  
+        create temp table tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+        
 	    INSERT INTO tmpEmissionsStatus 
 		 SELECT DISTINCT E.MON_PLAN_ID, E.RPT_PERIOD_ID 
            FROM camdecmpswks.EMISSION_EVALUATION E,
@@ -93,7 +94,7 @@ begin
 			  AND T.MON_PLAN_ID = vmon_plan_id
 			  AND T.RPT_PERIOD_ID = vperiod_id;
 
-   -- camdecmpswks.emission_evaluation has column=SUBMISSION_AVAILABILITY_CD
+            -- camdecmpswks.emission_evaluation has column=SUBMISSION_AVAILABILITY_CD
            OPEN EM_CSR;
 			 LOOP
 				FETCH Next from EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
@@ -102,21 +103,21 @@ begin
 				       from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
 					 -- Deleting Calculated data failed, bail (PJR)
 					 IF result = 'F' then
-					    return;
-				      end if;	
-					 RETURN NEXT;
+					    exit;
+				      end if;
 				 end loop;
 				CLOSE EM_CSR;	
              
-     end if; --vSubmittable if
-  return;
+    end if; --vSubmittable if
+    
+    RETURN NEXT; -- Add row to return table.
   
 exception when others then
     get stacked diagnostics error_msg:= message_text;
     result = 'F';
-     error_msg :='From update_ecmps_status_for_em_evaluation' ||' '|| error_msg;
+    error_msg :='From update_ecmps_status_for_em_evaluation' ||' '|| error_msg;
 	 
-   return;
+    RETURN NEXT; -- Add row to return table.
 END;
 $BODY$;
 

--- a/camdecmpswks/functions/update_ecmps_status_for_mp_evaluation.sql
+++ b/camdecmpswks/functions/update_ecmps_status_for_mp_evaluation.sql
@@ -23,32 +23,34 @@ begin
     vSubmittable :='N';
     error_msg := '';
     result := 'T';	
+    
     ----Remove check session for the MP that are not the current check session. --------
-    delete  from  camdecmpswks.check_session
-        where  process_cd = 'MP'
-          and  mon_plan_id = vMonPlanId
-          and  chk_session_id != vChkSessionId;
+    delete
+      from  camdecmpswks.check_session
+     where  process_cd = 'MP'
+       and  mon_plan_id = vMonPlanId
+       and  chk_session_id != vChkSessionId;
     
     ----Indicate that the MP does not need to be evaluated. -------
-	  update  camdecmpswks.monitor_plan 
-         set  needs_eval_flg = 'N',
-              last_evaluated_date = current_timestamp,
-              chk_session_id = vChkSessionId
-         where  mon_plan_id = vMonPlanId;   
+	update  camdecmpswks.monitor_plan 
+       set  needs_eval_flg = 'N',
+            last_evaluated_date = current_timestamp,
+            chk_session_id = vChkSessionId
+     where  mon_plan_id = vMonPlanId;   
     
     /*  Deteremine whether the MP is submittable and potentially update emission and QA information if it is. 
 	( May need to remove depending on decisions about QA and EM in the same workspace. ) */
    
-      select  coalesce ( max( 'Y' ), 'N' ) as Submittable
-          into  vSubmittable
-          from  camdecmpswks.monitor_plan mp
-          where mon_plan_id = vMonPlanId
-           and  ( updated_status_flg ='Y' or submission_availability_cd = 'REQUIRE' );
+    select  coalesce ( max( 'Y' ), 'N' ) as Submittable
+      into  vSubmittable
+      from  camdecmpswks.monitor_plan mp
+     where  mon_plan_id = vMonPlanId
+       and  ( updated_status_flg ='Y' or submission_availability_cd = 'REQUIRE' );
      
     
     if vSubmittable = 'Y' then     
-     ------- For QCE  -------
-       DELETE FROM camdecmpswks.CHECK_SESSION
+        ------- For QCE  -------
+        DELETE FROM camdecmpswks.CHECK_SESSION
 	     WHERE CHK_SESSION_ID IN 
 	     (SELECT qce.CHK_SESSION_ID 
 		    FROM camdecmpswks.QA_CERT_EVENT qce, camdecmpswks.MONITOR_PLAN_LOCATION mpl
@@ -56,16 +58,16 @@ begin
 			  AND (SUBMISSION_AVAILABILITY_CD = 'REQUIRE' OR UPDATED_STATUS_FLG = 'Y') 
 			  AND qce.MON_LOC_ID = mpl.MON_LOC_ID AND mpl.MON_PLAN_ID =vMonPlanId);
 		
-	 UPDATE camdecmpswks.QA_CERT_EVENT
-		SET NEEDS_EVAL_FLG = 'Y', 
-			CHK_SESSION_ID = null, 
-			UPDATE_DATE = current_timestamp
+        UPDATE camdecmpswks.QA_CERT_EVENT
+		 SET NEEDS_EVAL_FLG = 'Y', 
+		 	 CHK_SESSION_ID = null, 
+	 	 	 UPDATE_DATE = current_timestamp
 		 where NEEDS_EVAL_FLG = 'N' 
 		   AND (SUBMISSION_AVAILABILITY_CD = 'REQUIRE' OR UPDATED_STATUS_FLG = 'Y') 
 		   AND MON_LOC_ID in (select MON_LOC_ID from camdecmpswks.MONITOR_PLAN_LOCATION
 		          where MON_PLAN_ID =vMonPlanId);
 		   
-	   ---- For TEE ----------	
+        ---- For TEE ----------	
 		DELETE FROM camdecmpswks.CHECK_SESSION 
 		  WHERE CHK_SESSION_ID IN 
 		 (SELECT CHK_SESSION_ID 
@@ -74,7 +76,7 @@ begin
 			 (SUBMISSION_AVAILABILITY_CD= 'REQUIRE' OR UPDATED_STATUS_FLG= 'Y') AND
 				tee.MON_LOC_ID = mpl.MON_LOC_ID AND MON_PLAN_ID= vMonPlanId);
 							
-	UPDATE camdecmpswks.TEST_EXTENSION_EXEMPTION
+        UPDATE camdecmpswks.TEST_EXTENSION_EXEMPTION
 		 SET NEEDS_EVAL_FLG = 'Y', 
 		     CHK_SESSION_ID = null, 
 			 UPDATE_DATE = current_timestamp
@@ -83,56 +85,59 @@ begin
 			AND MON_LOC_ID in 
 		    (select MON_LOC_ID from camdecmpswks.MONITOR_PLAN_LOCATION where MON_PLAN_ID =vMonPlanId);	   
 		   
-    --------- wipe out calculated test data -----------
-	  create temp table tmpTestsStatus (TEST_SUM_ID character varying PRIMARY KEY);
-	  	INSERT INTO tmpTestsStatus 
+        --------- wipe out calculated test data -----------
+        create temp table tmpTestsStatus (TEST_SUM_ID character varying PRIMARY KEY);
+	  	 INSERT INTO tmpTestsStatus 
 		   SELECT distinct TEST_SUM_ID FROM camdecmpswks.TEST_SUMMARY ts
 			  INNER JOIN camdecmpswks.MONITOR_PLAN_LOCATION mpl 
 			        ON ts.MON_LOC_ID = mpl.MON_LOC_ID 
 			      WHERE NEEDS_EVAL_FLG = 'N' 
 				    AND MON_PLAN_ID = vMonPlanId;
 						  
-	 select * into result, error_msg 
+        select * into result, error_msg 
 	      from camdecmpswks.Delete_Calculated_QA_Data_from_Workspace();	
 						
-		   if result ='F' then
-		     return;
-		    end if;
+		if result = 'T' then
 			
-	 create temp table tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
-		--	update EM evaluation		
-		INSERT INTO tmpEmissionsStatus 
-			  SELECT DISTINCT E.MON_PLAN_ID, E.RPT_PERIOD_ID 
-				FROM camdecmpswks.EMISSION_EVALUATION E, camdecmpsaux.EM_SUBMISSION_ACCESS ESA
-					WHERE E.NEEDS_EVAL_FLG = 'N' 
-					  AND E.MON_PLAN_ID = ESA.MON_PLAN_ID 
-					  AND E.RPT_PERIOD_ID = ESA.RPT_PERIOD_ID 
-					  AND SUBMISSION_AVAILABILITY_CD IN ('REQUIRE','GRANTED')
-					  AND E.MON_PLAN_ID = vMonPlanId;						
+            create temp table tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+            
+            --	update EM evaluation		
+            INSERT INTO tmpEmissionsStatus 
+            SELECT DISTINCT E.MON_PLAN_ID, E.RPT_PERIOD_ID 
+              FROM camdecmpswks.EMISSION_EVALUATION E, camdecmpsaux.EM_SUBMISSION_ACCESS ESA
+             WHERE E.NEEDS_EVAL_FLG = 'N' 
+               AND E.MON_PLAN_ID = ESA.MON_PLAN_ID 
+               AND E.RPT_PERIOD_ID = ESA.RPT_PERIOD_ID 
+               AND SUBMISSION_AVAILABILITY_CD IN ('REQUIRE','GRANTED')
+               AND E.MON_PLAN_ID = vMonPlanId;						
 
-		  OPEN EM_CSR;
-			 LOOP
-				FETCH NEXT FROM EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
-  				  EXIT WHEN NOT FOUND;
-					 select * into result, error_msg 
-				     from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
-					IF result = 'F' then
-					 return;
-				    end if;	
-				 RETURN NEXT;
-			  END LOOP;
-			CLOSE EM_CSR;
-			
+            OPEN EM_CSR;
+            
+            LOOP
+                FETCH NEXT FROM EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
+            EXIT WHEN NOT FOUND;
+                select * into result, error_msg 
+                  from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
+                        
+                IF result = 'F' then
+                    exit;
+                end if;
+            END LOOP;
+            
+            CLOSE EM_CSR;
+            
+		end if;
 
-  end if;  --vSubmittable = 'Y' 
-   return;
+    end if;  --vSubmittable = 'Y' 
+   
+    RETURN NEXT; -- Add row to return table.
 
 exception when others then
     get stacked diagnostics error_msg := message_text;
     result = 'F';
     error_msg :='From update_ecmps_status_for_mp_evaluation' ||' '|| error_msg;
 	
-   return;
+    RETURN NEXT; -- Add row to return table.
 END;
 $BODY$;
 

--- a/camdecmpswks/functions/update_ecmps_status_for_qa_evaluation.sql
+++ b/camdecmpswks/functions/update_ecmps_status_for_qa_evaluation.sql
@@ -26,41 +26,43 @@ declare
 begin    
     error_msg := '';
     result := 'T';
- -- Remove check session for the record that are not the current check session. 
-	  DELETE FROM camdecmpswks.CHECK_SESSION 
-		WHERE TEST_SUM_ID = vTestSumId
-		 AND  CHK_SESSION_ID != vChkSessionId;	
+    
+    -- Remove check session for the record that are not the current check session. 
+	DELETE FROM camdecmpswks.CHECK_SESSION 
+	 WHERE TEST_SUM_ID = vTestSumId
+	   AND CHK_SESSION_ID != vChkSessionId;	
 		
 		 
-      UPDATE camdecmpswks.TEST_SUMMARY
-			SET NEEDS_EVAL_FLG	= 'N', 	
-			    CHK_SESSION_ID	= vChkSessionId	
-			WHERE TEST_SUM_ID = vTestSumId;
+    UPDATE camdecmpswks.TEST_SUMMARY
+	   SET NEEDS_EVAL_FLG	= 'N', 	
+		   CHK_SESSION_ID	= vChkSessionId	
+	 WHERE TEST_SUM_ID = vTestSumId;
  	
 		
-		UPDATE camdecmpswks.QA_SUPP_DATA
-			SET UPDATED_STATUS_FLG	= 'Y'
-			WHERE TEST_SUM_ID = vTestSumId 
-			  AND (submission_availability_cd IS NULL 
-			       OR submission_availability_cd = 'GRANTED' 
-				   OR submission_availability_cd = 'REQUIRE');
+	UPDATE camdecmpswks.QA_SUPP_DATA
+	   SET UPDATED_STATUS_FLG	= 'Y'
+	 WHERE TEST_SUM_ID = vTestSumId 
+	   AND (submission_availability_cd IS NULL 
+	       OR submission_availability_cd = 'GRANTED' 
+		   OR submission_availability_cd = 'REQUIRE');
 		
-		--common part for QA Test-------
-		vContinue:='Y';		
-			   --Check no test_sum_id or can't submit
-				SELECT count(*) into vCount
-					FROM camdecmpswks.QA_SUPP_DATA
-					 WHERE TEST_SUM_ID != vTestSumId 
-					   OR (	TEST_SUM_ID = vTestSumId AND 
-					          (submission_availability_cd IS NULL OR
-							submission_availability_cd = 'GRANTED' OR
-							submission_availability_cd = 'REQUIRE' ));
+	--common part for QA Test-------
+	vContinue:='Y';
+    
+    --Check no test_sum_id or can't submit
+    SELECT count(*) into vCount
+      FROM camdecmpswks.QA_SUPP_DATA
+     WHERE TEST_SUM_ID != vTestSumId 
+        OR (TEST_SUM_ID = vTestSumId AND 
+            (submission_availability_cd IS NULL OR
+            submission_availability_cd = 'GRANTED' OR
+            submission_availability_cd = 'REQUIRE' ));
 
-			  if vCount=0 then 
-				      vContinue:='N';
-                end if;
+	if vCount=0 then 
+		vContinue:='N';
+    end if;
 				   
-	 If vContinue='Y' then
+	If vContinue='Y' then
 	   	create temp table tmpTestsStatus (TEST_SUM_ID character varying PRIMARY KEY);
 			   	-- wipe out calculated test data for related tests		
 				   INSERT INTO tmpTestsStatus 
@@ -127,17 +129,16 @@ begin
 							LEFT OUTER JOIN camdecmpswks.QA_SUPP_DATA QS ON TT.TEST_SUM_ID = QS.TEST_SUM_ID
 							WHERE QS.SUBMISSION_AVAILABILITY_CD IS NULL OR
 								QS.SUBMISSION_AVAILABILITY_CD IN ('GRANTED','REQUIRE');
-	----calling deletion for ID in tmpTestsStatus
-		    select * into result, error_msg
-			  from camdecmpswks.Delete_Calculated_QA_Data_from_Workspace();			                   
-		     
-			  if result = 'F' then   -- 	del sp failed, bail the loop
-				 return;
-			  end if;			
-		
-	--	update EM evaluation
-	 create temp table camdecmpswks.tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
-		   INSERT INTO camdecmpswks.tmpEmissionsStatus 
+            
+        ----calling deletion for ID in tmpTestsStatus
+		select * into result, error_msg
+		  from camdecmpswks.Delete_Calculated_QA_Data_from_Workspace();			                   
+		 
+		if result = 'T' then
+            --	update EM evaluation
+            create temp table tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+            
+            INSERT INTO tmpEmissionsStatus 
 		     SELECT DISTINCT E.MON_PLAN_ID, E.RPT_PERIOD_ID
 						FROM camdecmpswks.EMISSION_EVALUATION E,
 							camdecmpsaux.EM_SUBMISSION_ACCESS ESA,
@@ -158,28 +159,31 @@ begin
 							(R.CALENDAR_YEAR > T.CALENDAR_YEAR OR 
 							(R.CALENDAR_YEAR = T.CALENDAR_YEAR AND R.QUARTER >= T.QUARTER)) 
 							AND	TEST_SUM_ID IN 
-							(select distinct test_sum_id from camdecmpswks.tmpTestsStatus);
+							(select distinct test_sum_id from tmpTestsStatus);
 	
-			OPEN EM_CSR;	
-			  LOOP
+			OPEN EM_CSR;
+            
+			LOOP
 				FETCH NEXT FROM EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
-				   EXIT WHEN NOT FOUND;
+			EXIT WHEN NOT FOUND;
 				   select * into result, error_msg 
 				   from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
 					IF result = 'F' then
-					 return;
+					 exit;
 				    end if;
-				 RETURN NEXT;
-			  END LOOP;
+			END LOOP;
+            
 			CLOSE EM_CSR;
-   end if;   --vContinue if
-   return;
+		end if;			
+    end if;   --vContinue if
+    
+   return next; -- Add row to return table.
 
 exception when others then
     get stacked diagnostics error_msg := message_text;
     result = 'F';
     error_msg :='From update_ecmps_status_for_qa_evaluation ' ||' '|| error_msg;
 	
-   return;
+   return next; -- Add row to return table.
 END;
 $BODY$;

--- a/camdecmpswks/functions/update_ecmps_status_for_qce_evaluation.sql
+++ b/camdecmpswks/functions/update_ecmps_status_for_qce_evaluation.sql
@@ -24,69 +24,71 @@ begin
     error_msg := '';
     result := 'T';
 	
--- Remove check session for the record that are not the current check session. 
-	  DELETE FROM camdecmpswks.CHECK_SESSION 
-		WHERE QA_CERT_EVENT_ID = vQceId
-		 AND  CHK_SESSION_ID != vChkSessionId;	
+    -- Remove check session for the record that are not the current check session. 
+	DELETE FROM camdecmpswks.CHECK_SESSION 
+	 WHERE QA_CERT_EVENT_ID = vQceId
+	   AND CHK_SESSION_ID != vChkSessionId;	
 		 
-       UPDATE camdecmpswks.QA_CERT_EVENT
-			SET NEEDS_EVAL_FLG	= 'N',	
-			    CHK_SESSION_ID	= vChkSessionId	
-			WHERE QA_CERT_EVENT_ID = vQceId;
+    UPDATE camdecmpswks.QA_CERT_EVENT
+	   SET NEEDS_EVAL_FLG	= 'N',	
+		   CHK_SESSION_ID	= vChkSessionId	
+	 WHERE QA_CERT_EVENT_ID = vQceId;
 	   
-	  select  coalesce ( max( 'Y' ), 'N' ) as Submittable
-             into  vSubmittable
-         from  camdecmpswks.QA_CERT_EVENT
-          where  QA_CERT_EVENT_ID = vQceId
-           and (UPDATED_STATUS_FLG ='Y' or SUBMISSION_AVAILABILITY_CD = 'REQUIRE');			
+	select  coalesce ( max( 'Y' ), 'N' ) as Submittable
+      into  vSubmittable
+      from  camdecmpswks.QA_CERT_EVENT
+     where  QA_CERT_EVENT_ID = vQceId
+       and  (UPDATED_STATUS_FLG ='Y' or SUBMISSION_AVAILABILITY_CD = 'REQUIRE');			
       
 	----------------------------------------------
-      --EM evaluation part 
+    --EM evaluation part 
     IF vSubmittable = 'Y' then
-    create temp table camdecmpswks.tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+        create temp table tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+        
 		--	update EM evaluation
-			INSERT INTO camdecmpswks.tmpEmissionsStatus 
-				SELECT DISTINCT E.MON_PLAN_ID, E.RPT_PERIOD_ID
-					FROM camdecmps.EMISSION_EVALUATION E,
-					camdecmpsaux.EM_SUBMISSION_ACCESS ESA,
-					camdecmps.MONITOR_PLAN_LOCATION M, 
-					camdecmpsmd.REPORTING_PERIOD R,
-					(SELECT MON_LOC_ID, QA_CERT_EVENT_ID,
-						(SELECT EXTRACT('year' FROM qa_cert_event_date ) )AS CALENDAR_YEAR,
-						FLOOR((extract(month from QA_CERT_EVENT_DATE) + 2) / 3) AS QUARTER
-						FROM camdecmps.QA_CERT_EVENT) T
-					WHERE E.MON_PLAN_ID = M.MON_PLAN_ID AND 
-							E.RPT_PERIOD_ID = R.RPT_PERIOD_ID AND
-							E.NEEDS_EVAL_FLG = 'N' AND
-							E.MON_PLAN_ID = ESA.MON_PLAN_ID AND 
-							E.RPT_PERIOD_ID = ESA.RPT_PERIOD_ID AND
-							ESA.SUBMISSION_AVAILABILITY_CD IN ('GRANTED','REQUIRE') AND
-							M.MON_LOC_ID = T.MON_LOC_ID AND
-							(R.CALENDAR_YEAR > T.CALENDAR_YEAR OR 
-							(R.CALENDAR_YEAR = T.CALENDAR_YEAR AND R.QUARTER >= T.QUARTER)) AND
-							QA_CERT_EVENT_ID =vQceId;					
+		INSERT INTO tmpEmissionsStatus 
+			SELECT DISTINCT E.MON_PLAN_ID, E.RPT_PERIOD_ID
+				FROM camdecmps.EMISSION_EVALUATION E,
+				camdecmpsaux.EM_SUBMISSION_ACCESS ESA,
+				camdecmps.MONITOR_PLAN_LOCATION M, 
+				camdecmpsmd.REPORTING_PERIOD R,
+				(SELECT MON_LOC_ID, QA_CERT_EVENT_ID,
+					(SELECT EXTRACT('year' FROM qa_cert_event_date ) )AS CALENDAR_YEAR,
+					FLOOR((extract(month from QA_CERT_EVENT_DATE) + 2) / 3) AS QUARTER
+					FROM camdecmps.QA_CERT_EVENT) T
+				WHERE E.MON_PLAN_ID = M.MON_PLAN_ID AND 
+						E.RPT_PERIOD_ID = R.RPT_PERIOD_ID AND
+						E.NEEDS_EVAL_FLG = 'N' AND
+						E.MON_PLAN_ID = ESA.MON_PLAN_ID AND 
+						E.RPT_PERIOD_ID = ESA.RPT_PERIOD_ID AND
+						ESA.SUB_AVAILABILITY_CD IN ('GRANTED','REQUIRE') AND
+						M.MON_LOC_ID = T.MON_LOC_ID AND
+						(R.CALENDAR_YEAR > T.CALENDAR_YEAR OR 
+						(R.CALENDAR_YEAR = T.CALENDAR_YEAR AND R.QUARTER >= T.QUARTER)) AND
+						QA_CERT_EVENT_ID =vQceId;					
 
-			OPEN EM_CSR;	
-			  LOOP
-				FETCH NEXT FROM EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
-                  EXIT WHEN NOT FOUND;
-				   select * into result, error_msg 
-				   from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
-					IF result = 'F' then
-					 return;
-				    end if;
-				 RETURN NEXT;
-               END LOOP;
-			CLOSE EM_CSR;
+		OPEN EM_CSR;	
+		LOOP
+			FETCH NEXT FROM EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
+        EXIT WHEN NOT FOUND;
+		    select * into result, error_msg 
+		      from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
+            
+			if result = 'F' then
+                exit;
+			end if;
+        END LOOP;
+		CLOSE EM_CSR;
 				
-	  end if; --vSubmittable if
-   return;
+	end if; --vSubmittable if
+    
+    return next; -- Add row to return table.
 
 exception when others then
     get stacked diagnostics error_msg := message_text;
     result = 'F';
     error_msg :='From update_ecmps_status_for_qce_evaluation' ||' '|| error_msg;
 	
-   return;
+    return next; -- Add row to return table.
 END;
 $BODY$;

--- a/camdecmpswks/functions/update_ecmps_status_for_tee_evaluation.sql
+++ b/camdecmpswks/functions/update_ecmps_status_for_tee_evaluation.sql
@@ -23,27 +23,28 @@ begin
     error_msg := '';
     result := 'T';
 	
- -- Remove check session for the record that are not the current check session. 
-	  DELETE FROM camdecmpswks.CHECK_SESSION 
-		WHERE TEST_EXTENSION_EXEMPTION_ID = vteeid
-		 AND  CHK_SESSION_ID != vchksessionid;	
+    -- Remove check session for the record that are not the current check session. 
+	DELETE FROM camdecmpswks.CHECK_SESSION 
+	 WHERE TEST_EXTENSION_EXEMPTION_ID = vteeid
+	   AND CHK_SESSION_ID != vchksessionid;	
 		 
-       UPDATE camdecmpswks.TEST_EXTENSION_EXEMPTION
-			SET NEEDS_EVAL_FLG	= 'N',	
-			    CHK_SESSION_ID = vchksessionid	
-		WHERE TEST_EXTENSION_EXEMPTION_ID = vteeid;
+    UPDATE camdecmpswks.TEST_EXTENSION_EXEMPTION
+	   SET NEEDS_EVAL_FLG	= 'N',	
+		   CHK_SESSION_ID = vchksessionid	
+	 WHERE TEST_EXTENSION_EXEMPTION_ID = vteeid;
 	 
-	  select  coalesce ( max( 'Y' ), 'N' ) as Submittable
-          into  vSubmittable
-         from  camdecmpswks.TEST_EXTENSION_EXEMPTION
-           where   TEST_EXTENSION_EXEMPTION_ID = vteeid
-            and  ( UPDATED_STATUS_FLG ='Y' or SUBMISSION_AVAILABILITY_CD = 'REQUIRE');			
+	select  coalesce ( max( 'Y' ), 'N' ) as Submittable
+      into  vSubmittable
+      from  camdecmpswks.TEST_EXTENSION_EXEMPTION
+     where   TEST_EXTENSION_EXEMPTION_ID = vteeid
+       and  ( UPDATED_STATUS_FLG ='Y' or SUBMISSION_AVAILABILITY_CD = 'REQUIRE');			
       
 	----------------------------------------------
-     IF vSubmittable = 'Y' then
-       create temp table camdecmpswks.tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+    if vSubmittable = 'Y' then
+        create temp table tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+        
 		--	update EM evaluation
-		INSERT INTO camdecmpswks.tmpEmissionsStatus 
+		INSERT INTO tmpEmissionsStatus 
 			SELECT DISTINCT E.MON_PLAN_ID, E.RPT_PERIOD_ID
 					FROM camdecmpswks.EMISSION_EVALUATION E,
 					camdecmpsaux.EM_SUBMISSION_ACCESS ESA,
@@ -63,26 +64,27 @@ begin
 							(R.CALENDAR_YEAR = T.CALENDAR_YEAR AND R.QUARTER >= T.QUARTER))
 				  AND TEST_EXTENSION_EXEMPTION_ID =vteeid;
 							
-			OPEN EM_CSR;
-			  LOOP
-				FETCH NEXT FROM EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
-  				  EXIT WHEN NOT FOUND;
-				   select * into result, error_msg 
-				     from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
-					IF result = 'F' then
-					 return;
-				    end if;
-				  RETURN NEXT;
-				END LOOP;
-				CLOSE EM_CSR;	
-	 end if; --vSubmittable
-   return;
+		OPEN EM_CSR;
+		LOOP
+			FETCH NEXT FROM EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
+  		EXIT WHEN NOT FOUND;
+		    select * into result, error_msg 
+		      from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
+			
+            if result = 'F' then
+                exit;
+			end if;
+		END LOOP;
+		CLOSE EM_CSR;	
+	end if; --vSubmittable
+    
+    return next; -- Add row to return table.
 
 exception when others then
     get stacked diagnostics error_msg := message_text;
     result = 'F';
     error_msg :='From update_ecmps_status_for_tee_evaluation' ||' '|| error_msg;
 	
-   return;
+    return next; -- Add row to return table.
 END;
 $BODY$;

--- a/deployments/ecmps/release-v2.0-fix/Sprint13/6067/delete_calculated_em_data_from_workspace.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint13/6067/delete_calculated_em_data_from_workspace.sql
@@ -19,7 +19,7 @@ BEGIN
     error_msg := '';
     result := 'T';	 
 
-	 create temp table tmpMonInfo(MON_PLAN_ID character varying,
+	create temp table tmpMonInfo(MON_PLAN_ID character varying,
 	          MON_LOC_ID character varying, RPT_PERIOD_ID int);
 	
          ----- Get the MON_LOC_IDs for this MP
@@ -127,13 +127,13 @@ BEGIN
 	 select * into result, error_msg 
 	   from camdecmpswks.emissions_grid_remove_eval(vmonplan_id, vrptperiod_id );	
 	
-	 return;
+	RETURN NEXT; -- Add row to return table.
 
 exception when others then
     get stacked diagnostics error_msg := message_text;
     result = 'F'; 
 	error_msg :='From delete_calculated_em_data_from_workspace '||' '|| message_text;
 	
-   return;
+    RETURN NEXT; -- Add row to return table.
 END;
 $BODY$;

--- a/deployments/ecmps/release-v2.0-fix/Sprint13/6067/emissions_grid_remove_eval.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint13/6067/emissions_grid_remove_eval.sql
@@ -164,13 +164,13 @@ BEGIN
 		where MON_PLAN_ID =vmonplan_id
 		  and RPT_PERIOD_ID = vrptperiod_id;
 
- return;
+    RETURN NEXT; -- Add row to return table.
 
 exception when others then
     get stacked diagnostics error_msg := message_text;
     result = 'F';  
 	error_msg :='From emissions_grid_remove_eval '||' '|| message_text;
 	
-   return;
+    RETURN NEXT; -- Add row to return table.
 END;
 $BODY$;

--- a/deployments/ecmps/release-v2.0-fix/Sprint13/6067/update_ecmps_status_for_em_evaluation.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint13/6067/update_ecmps_status_for_em_evaluation.sql
@@ -28,9 +28,9 @@ begin
 
 	select  coalesce ( max( 'Y' ), 'N' ) as Submittable
       into  vSubmittable
-      from  camdecmpswks.EM_SUBMISSION_ACCESS
+      from  camdecmpsaux.EM_SUBMISSION_ACCESS
      where  mon_plan_id = vmon_plan_id
-       and  SUBMISSION_AVAILABILITY_CD IN ('GRANTED', 'REQUIRE')
+       and  sub_availability_cd IN ('GRANTED', 'REQUIRE')
 	   and  RPT_PERIOD_ID = vperiod_id;
 	   
  	-- delete old evaluation data from check logs	  
@@ -55,23 +55,24 @@ begin
 	CALL camdecmpswks.refresh_emissions_views(vmon_plan_id,vYear, vQuarter);	
 
 	-- Update Monitoring Plan Needs Evaluation, if needed
-      UPDATE  camdecmpswks.MONITOR_PLAN
-           SET NEEDS_EVAL_FLG = 'Y',
-               CHK_SESSION_ID = null
-        WHERE MON_PLAN_ID = vmon_plan_id
-          AND  EXISTS
-              ( SELECT  1
-                   FROM  camdecmpswks.CHECK_LOG chl
-                    JOIN camdecmpsmd.CHECK_CATALOG_RESULT ccr ON ccr.CHECK_CATALOG_RESULT_ID = chl.CHECK_CATALOG_RESULT_ID
-                    JOIN camdecmpsmd.CHECK_CATALOG chk ON chk.CHECK_CATALOG_ID = ccr.CHECK_CATALOG_ID
-                     WHERE  chl.CHK_SESSION_ID = vchk_session_id
-                       AND  chk.CHECK_TYPE_CD = 'HOURGEN'
-                       AND  chk.CHECK_NUMBER = 8
-                       AND  ccr.CHECK_RESULT = 'C'
-                );	
+    UPDATE  camdecmpswks.MONITOR_PLAN
+       SET NEEDS_EVAL_FLG = 'Y',
+           CHK_SESSION_ID = null
+     WHERE MON_PLAN_ID = vmon_plan_id
+       AND EXISTS
+           ( SELECT  1
+               FROM  camdecmpswks.CHECK_LOG chl
+                     JOIN camdecmpsmd.CHECK_CATALOG_RESULT ccr ON ccr.CHECK_CATALOG_RESULT_ID = chl.CHECK_CATALOG_RESULT_ID
+                     JOIN camdecmpsmd.CHECK_CATALOG chk ON chk.CHECK_CATALOG_ID = ccr.CHECK_CATALOG_ID
+              WHERE  chl.CHK_SESSION_ID = vchk_session_id
+                AND  chk.CHECK_TYPE_CD = 'HOURGEN'
+                AND  chk.CHECK_NUMBER = 8
+                AND  ccr.CHECK_RESULT = 'C'
+           );	
  
-   if vSubmittable = 'Y' then  
-     create temp table tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+    if vSubmittable = 'Y' then  
+        create temp table tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+        
 	    INSERT INTO tmpEmissionsStatus 
 		 SELECT DISTINCT E.MON_PLAN_ID, E.RPT_PERIOD_ID 
            FROM camdecmpswks.EMISSION_EVALUATION E,
@@ -93,7 +94,7 @@ begin
 			  AND T.MON_PLAN_ID = vmon_plan_id
 			  AND T.RPT_PERIOD_ID = vperiod_id;
 
-   -- camdecmpswks.emission_evaluation has column=SUBMISSION_AVAILABILITY_CD
+            -- camdecmpswks.emission_evaluation has column=SUBMISSION_AVAILABILITY_CD
            OPEN EM_CSR;
 			 LOOP
 				FETCH Next from EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
@@ -102,21 +103,21 @@ begin
 				       from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
 					 -- Deleting Calculated data failed, bail (PJR)
 					 IF result = 'F' then
-					    return;
-				      end if;	
-					 RETURN NEXT;
+					    exit;
+				      end if;
 				 end loop;
 				CLOSE EM_CSR;	
              
-     end if; --vSubmittable if
-  return;
+    end if; --vSubmittable if
+    
+    RETURN NEXT; -- Add row to return table.
   
 exception when others then
     get stacked diagnostics error_msg:= message_text;
     result = 'F';
-     error_msg :='From update_ecmps_status_for_em_evaluation' ||' '|| error_msg;
+    error_msg :='From update_ecmps_status_for_em_evaluation' ||' '|| error_msg;
 	 
-   return;
+    RETURN NEXT; -- Add row to return table.
 END;
 $BODY$;
 

--- a/deployments/ecmps/release-v2.0-fix/Sprint13/6067/update_ecmps_status_for_mp_evaluation.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint13/6067/update_ecmps_status_for_mp_evaluation.sql
@@ -23,32 +23,34 @@ begin
     vSubmittable :='N';
     error_msg := '';
     result := 'T';	
+    
     ----Remove check session for the MP that are not the current check session. --------
-    delete  from  camdecmpswks.check_session
-        where  process_cd = 'MP'
-          and  mon_plan_id = vMonPlanId
-          and  chk_session_id != vChkSessionId;
+    delete
+      from  camdecmpswks.check_session
+     where  process_cd = 'MP'
+       and  mon_plan_id = vMonPlanId
+       and  chk_session_id != vChkSessionId;
     
     ----Indicate that the MP does not need to be evaluated. -------
-	  update  camdecmpswks.monitor_plan 
-         set  needs_eval_flg = 'N',
-              last_evaluated_date = current_timestamp,
-              chk_session_id = vChkSessionId
-         where  mon_plan_id = vMonPlanId;   
+	update  camdecmpswks.monitor_plan 
+       set  needs_eval_flg = 'N',
+            last_evaluated_date = current_timestamp,
+            chk_session_id = vChkSessionId
+     where  mon_plan_id = vMonPlanId;   
     
     /*  Deteremine whether the MP is submittable and potentially update emission and QA information if it is. 
 	( May need to remove depending on decisions about QA and EM in the same workspace. ) */
    
-      select  coalesce ( max( 'Y' ), 'N' ) as Submittable
-          into  vSubmittable
-          from  camdecmpswks.monitor_plan mp
-          where mon_plan_id = vMonPlanId
-           and  ( updated_status_flg ='Y' or submission_availability_cd = 'REQUIRE' );
+    select  coalesce ( max( 'Y' ), 'N' ) as Submittable
+      into  vSubmittable
+      from  camdecmpswks.monitor_plan mp
+     where  mon_plan_id = vMonPlanId
+       and  ( updated_status_flg ='Y' or submission_availability_cd = 'REQUIRE' );
      
     
     if vSubmittable = 'Y' then     
-     ------- For QCE  -------
-       DELETE FROM camdecmpswks.CHECK_SESSION
+        ------- For QCE  -------
+        DELETE FROM camdecmpswks.CHECK_SESSION
 	     WHERE CHK_SESSION_ID IN 
 	     (SELECT qce.CHK_SESSION_ID 
 		    FROM camdecmpswks.QA_CERT_EVENT qce, camdecmpswks.MONITOR_PLAN_LOCATION mpl
@@ -56,16 +58,16 @@ begin
 			  AND (SUBMISSION_AVAILABILITY_CD = 'REQUIRE' OR UPDATED_STATUS_FLG = 'Y') 
 			  AND qce.MON_LOC_ID = mpl.MON_LOC_ID AND mpl.MON_PLAN_ID =vMonPlanId);
 		
-	 UPDATE camdecmpswks.QA_CERT_EVENT
-		SET NEEDS_EVAL_FLG = 'Y', 
-			CHK_SESSION_ID = null, 
-			UPDATE_DATE = current_timestamp
+        UPDATE camdecmpswks.QA_CERT_EVENT
+		 SET NEEDS_EVAL_FLG = 'Y', 
+		 	 CHK_SESSION_ID = null, 
+	 	 	 UPDATE_DATE = current_timestamp
 		 where NEEDS_EVAL_FLG = 'N' 
 		   AND (SUBMISSION_AVAILABILITY_CD = 'REQUIRE' OR UPDATED_STATUS_FLG = 'Y') 
 		   AND MON_LOC_ID in (select MON_LOC_ID from camdecmpswks.MONITOR_PLAN_LOCATION
 		          where MON_PLAN_ID =vMonPlanId);
 		   
-	   ---- For TEE ----------	
+        ---- For TEE ----------	
 		DELETE FROM camdecmpswks.CHECK_SESSION 
 		  WHERE CHK_SESSION_ID IN 
 		 (SELECT CHK_SESSION_ID 
@@ -74,7 +76,7 @@ begin
 			 (SUBMISSION_AVAILABILITY_CD= 'REQUIRE' OR UPDATED_STATUS_FLG= 'Y') AND
 				tee.MON_LOC_ID = mpl.MON_LOC_ID AND MON_PLAN_ID= vMonPlanId);
 							
-	UPDATE camdecmpswks.TEST_EXTENSION_EXEMPTION
+        UPDATE camdecmpswks.TEST_EXTENSION_EXEMPTION
 		 SET NEEDS_EVAL_FLG = 'Y', 
 		     CHK_SESSION_ID = null, 
 			 UPDATE_DATE = current_timestamp
@@ -83,56 +85,59 @@ begin
 			AND MON_LOC_ID in 
 		    (select MON_LOC_ID from camdecmpswks.MONITOR_PLAN_LOCATION where MON_PLAN_ID =vMonPlanId);	   
 		   
-    --------- wipe out calculated test data -----------
-	  create temp table tmpTestsStatus (TEST_SUM_ID character varying PRIMARY KEY);
-	  	INSERT INTO tmpTestsStatus 
+        --------- wipe out calculated test data -----------
+        create temp table tmpTestsStatus (TEST_SUM_ID character varying PRIMARY KEY);
+	  	 INSERT INTO tmpTestsStatus 
 		   SELECT distinct TEST_SUM_ID FROM camdecmpswks.TEST_SUMMARY ts
 			  INNER JOIN camdecmpswks.MONITOR_PLAN_LOCATION mpl 
 			        ON ts.MON_LOC_ID = mpl.MON_LOC_ID 
 			      WHERE NEEDS_EVAL_FLG = 'N' 
 				    AND MON_PLAN_ID = vMonPlanId;
 						  
-	 select * into result, error_msg 
+        select * into result, error_msg 
 	      from camdecmpswks.Delete_Calculated_QA_Data_from_Workspace();	
 						
-		   if result ='F' then
-		     return;
-		    end if;
+		if result = 'T' then
 			
-	 create temp table tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
-		--	update EM evaluation		
-		INSERT INTO tmpEmissionsStatus 
-			  SELECT DISTINCT E.MON_PLAN_ID, E.RPT_PERIOD_ID 
-				FROM camdecmpswks.EMISSION_EVALUATION E, camdecmpsaux.EM_SUBMISSION_ACCESS ESA
-					WHERE E.NEEDS_EVAL_FLG = 'N' 
-					  AND E.MON_PLAN_ID = ESA.MON_PLAN_ID 
-					  AND E.RPT_PERIOD_ID = ESA.RPT_PERIOD_ID 
-					  AND SUBMISSION_AVAILABILITY_CD IN ('REQUIRE','GRANTED')
-					  AND E.MON_PLAN_ID = vMonPlanId;						
+            create temp table tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+            
+            --	update EM evaluation		
+            INSERT INTO tmpEmissionsStatus 
+            SELECT DISTINCT E.MON_PLAN_ID, E.RPT_PERIOD_ID 
+              FROM camdecmpswks.EMISSION_EVALUATION E, camdecmpsaux.EM_SUBMISSION_ACCESS ESA
+             WHERE E.NEEDS_EVAL_FLG = 'N' 
+               AND E.MON_PLAN_ID = ESA.MON_PLAN_ID 
+               AND E.RPT_PERIOD_ID = ESA.RPT_PERIOD_ID 
+               AND SUBMISSION_AVAILABILITY_CD IN ('REQUIRE','GRANTED')
+               AND E.MON_PLAN_ID = vMonPlanId;						
 
-		  OPEN EM_CSR;
-			 LOOP
-				FETCH NEXT FROM EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
-  				  EXIT WHEN NOT FOUND;
-					 select * into result, error_msg 
-				     from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
-					IF result = 'F' then
-					 return;
-				    end if;	
-				 RETURN NEXT;
-			  END LOOP;
-			CLOSE EM_CSR;
-			
+            OPEN EM_CSR;
+            
+            LOOP
+                FETCH NEXT FROM EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
+            EXIT WHEN NOT FOUND;
+                select * into result, error_msg 
+                  from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
+                        
+                IF result = 'F' then
+                    exit;
+                end if;
+            END LOOP;
+            
+            CLOSE EM_CSR;
+            
+		end if;
 
-  end if;  --vSubmittable = 'Y' 
-   return;
+    end if;  --vSubmittable = 'Y' 
+   
+    RETURN NEXT; -- Add row to return table.
 
 exception when others then
     get stacked diagnostics error_msg := message_text;
     result = 'F';
     error_msg :='From update_ecmps_status_for_mp_evaluation' ||' '|| error_msg;
 	
-   return;
+    RETURN NEXT; -- Add row to return table.
 END;
 $BODY$;
 

--- a/deployments/ecmps/release-v2.0-fix/Sprint13/6067/update_ecmps_status_for_qa_evaluation.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint13/6067/update_ecmps_status_for_qa_evaluation.sql
@@ -26,41 +26,43 @@ declare
 begin    
     error_msg := '';
     result := 'T';
- -- Remove check session for the record that are not the current check session. 
-	  DELETE FROM camdecmpswks.CHECK_SESSION 
-		WHERE TEST_SUM_ID = vTestSumId
-		 AND  CHK_SESSION_ID != vChkSessionId;	
+    
+    -- Remove check session for the record that are not the current check session. 
+	DELETE FROM camdecmpswks.CHECK_SESSION 
+	 WHERE TEST_SUM_ID = vTestSumId
+	   AND CHK_SESSION_ID != vChkSessionId;	
 		
 		 
-      UPDATE camdecmpswks.TEST_SUMMARY
-			SET NEEDS_EVAL_FLG	= 'N', 	
-			    CHK_SESSION_ID	= vChkSessionId	
-			WHERE TEST_SUM_ID = vTestSumId;
+    UPDATE camdecmpswks.TEST_SUMMARY
+	   SET NEEDS_EVAL_FLG	= 'N', 	
+		   CHK_SESSION_ID	= vChkSessionId	
+	 WHERE TEST_SUM_ID = vTestSumId;
  	
 		
-		UPDATE camdecmpswks.QA_SUPP_DATA
-			SET UPDATED_STATUS_FLG	= 'Y'
-			WHERE TEST_SUM_ID = vTestSumId 
-			  AND (submission_availability_cd IS NULL 
-			       OR submission_availability_cd = 'GRANTED' 
-				   OR submission_availability_cd = 'REQUIRE');
+	UPDATE camdecmpswks.QA_SUPP_DATA
+	   SET UPDATED_STATUS_FLG	= 'Y'
+	 WHERE TEST_SUM_ID = vTestSumId 
+	   AND (submission_availability_cd IS NULL 
+	       OR submission_availability_cd = 'GRANTED' 
+		   OR submission_availability_cd = 'REQUIRE');
 		
-		--common part for QA Test-------
-		vContinue:='Y';		
-			   --Check no test_sum_id or can't submit
-				SELECT count(*) into vCount
-					FROM camdecmpswks.QA_SUPP_DATA
-					 WHERE TEST_SUM_ID != vTestSumId 
-					   OR (	TEST_SUM_ID = vTestSumId AND 
-					          (submission_availability_cd IS NULL OR
-							submission_availability_cd = 'GRANTED' OR
-							submission_availability_cd = 'REQUIRE' ));
+	--common part for QA Test-------
+	vContinue:='Y';
+    
+    --Check no test_sum_id or can't submit
+    SELECT count(*) into vCount
+      FROM camdecmpswks.QA_SUPP_DATA
+     WHERE TEST_SUM_ID != vTestSumId 
+        OR (TEST_SUM_ID = vTestSumId AND 
+            (submission_availability_cd IS NULL OR
+            submission_availability_cd = 'GRANTED' OR
+            submission_availability_cd = 'REQUIRE' ));
 
-			  if vCount=0 then 
-				      vContinue:='N';
-                end if;
+	if vCount=0 then 
+		vContinue:='N';
+    end if;
 				   
-	 If vContinue='Y' then
+	If vContinue='Y' then
 	   	create temp table tmpTestsStatus (TEST_SUM_ID character varying PRIMARY KEY);
 			   	-- wipe out calculated test data for related tests		
 				   INSERT INTO tmpTestsStatus 
@@ -127,17 +129,16 @@ begin
 							LEFT OUTER JOIN camdecmpswks.QA_SUPP_DATA QS ON TT.TEST_SUM_ID = QS.TEST_SUM_ID
 							WHERE QS.SUBMISSION_AVAILABILITY_CD IS NULL OR
 								QS.SUBMISSION_AVAILABILITY_CD IN ('GRANTED','REQUIRE');
-	----calling deletion for ID in tmpTestsStatus
-		    select * into result, error_msg
-			  from camdecmpswks.Delete_Calculated_QA_Data_from_Workspace();			                   
-		     
-			  if result = 'F' then   -- 	del sp failed, bail the loop
-				 return;
-			  end if;			
-		
-	--	update EM evaluation
-	 create temp table camdecmpswks.tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
-		   INSERT INTO camdecmpswks.tmpEmissionsStatus 
+            
+        ----calling deletion for ID in tmpTestsStatus
+		select * into result, error_msg
+		  from camdecmpswks.Delete_Calculated_QA_Data_from_Workspace();			                   
+		 
+		if result = 'T' then
+            --	update EM evaluation
+            create temp table tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+            
+            INSERT INTO tmpEmissionsStatus 
 		     SELECT DISTINCT E.MON_PLAN_ID, E.RPT_PERIOD_ID
 						FROM camdecmpswks.EMISSION_EVALUATION E,
 							camdecmpsaux.EM_SUBMISSION_ACCESS ESA,
@@ -158,28 +159,31 @@ begin
 							(R.CALENDAR_YEAR > T.CALENDAR_YEAR OR 
 							(R.CALENDAR_YEAR = T.CALENDAR_YEAR AND R.QUARTER >= T.QUARTER)) 
 							AND	TEST_SUM_ID IN 
-							(select distinct test_sum_id from camdecmpswks.tmpTestsStatus);
+							(select distinct test_sum_id from tmpTestsStatus);
 	
-			OPEN EM_CSR;	
-			  LOOP
+			OPEN EM_CSR;
+            
+			LOOP
 				FETCH NEXT FROM EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
-				   EXIT WHEN NOT FOUND;
+			EXIT WHEN NOT FOUND;
 				   select * into result, error_msg 
 				   from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
 					IF result = 'F' then
-					 return;
+					 exit;
 				    end if;
-				 RETURN NEXT;
-			  END LOOP;
+			END LOOP;
+            
 			CLOSE EM_CSR;
-   end if;   --vContinue if
-   return;
+		end if;			
+    end if;   --vContinue if
+    
+   return next; -- Add row to return table.
 
 exception when others then
     get stacked diagnostics error_msg := message_text;
     result = 'F';
     error_msg :='From update_ecmps_status_for_qa_evaluation ' ||' '|| error_msg;
 	
-   return;
+   return next; -- Add row to return table.
 END;
 $BODY$;

--- a/deployments/ecmps/release-v2.0-fix/Sprint13/6067/update_ecmps_status_for_qce_evaluation.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint13/6067/update_ecmps_status_for_qce_evaluation.sql
@@ -24,69 +24,71 @@ begin
     error_msg := '';
     result := 'T';
 	
--- Remove check session for the record that are not the current check session. 
-	  DELETE FROM camdecmpswks.CHECK_SESSION 
-		WHERE QA_CERT_EVENT_ID = vQceId
-		 AND  CHK_SESSION_ID != vChkSessionId;	
+    -- Remove check session for the record that are not the current check session. 
+	DELETE FROM camdecmpswks.CHECK_SESSION 
+	 WHERE QA_CERT_EVENT_ID = vQceId
+	   AND CHK_SESSION_ID != vChkSessionId;	
 		 
-       UPDATE camdecmpswks.QA_CERT_EVENT
-			SET NEEDS_EVAL_FLG	= 'N',	
-			    CHK_SESSION_ID	= vChkSessionId	
-			WHERE QA_CERT_EVENT_ID = vQceId;
+    UPDATE camdecmpswks.QA_CERT_EVENT
+	   SET NEEDS_EVAL_FLG	= 'N',	
+		   CHK_SESSION_ID	= vChkSessionId	
+	 WHERE QA_CERT_EVENT_ID = vQceId;
 	   
-	  select  coalesce ( max( 'Y' ), 'N' ) as Submittable
-             into  vSubmittable
-         from  camdecmpswks.QA_CERT_EVENT
-          where  QA_CERT_EVENT_ID = vQceId
-           and (UPDATED_STATUS_FLG ='Y' or SUBMISSION_AVAILABILITY_CD = 'REQUIRE');			
+	select  coalesce ( max( 'Y' ), 'N' ) as Submittable
+      into  vSubmittable
+      from  camdecmpswks.QA_CERT_EVENT
+     where  QA_CERT_EVENT_ID = vQceId
+       and  (UPDATED_STATUS_FLG ='Y' or SUBMISSION_AVAILABILITY_CD = 'REQUIRE');			
       
 	----------------------------------------------
-      --EM evaluation part 
+    --EM evaluation part 
     IF vSubmittable = 'Y' then
-    create temp table camdecmpswks.tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+        create temp table tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+        
 		--	update EM evaluation
-			INSERT INTO camdecmpswks.tmpEmissionsStatus 
-				SELECT DISTINCT E.MON_PLAN_ID, E.RPT_PERIOD_ID
-					FROM camdecmps.EMISSION_EVALUATION E,
-					camdecmpsaux.EM_SUBMISSION_ACCESS ESA,
-					camdecmps.MONITOR_PLAN_LOCATION M, 
-					camdecmpsmd.REPORTING_PERIOD R,
-					(SELECT MON_LOC_ID, QA_CERT_EVENT_ID,
-						(SELECT EXTRACT('year' FROM qa_cert_event_date ) )AS CALENDAR_YEAR,
-						FLOOR((extract(month from QA_CERT_EVENT_DATE) + 2) / 3) AS QUARTER
-						FROM camdecmps.QA_CERT_EVENT) T
-					WHERE E.MON_PLAN_ID = M.MON_PLAN_ID AND 
-							E.RPT_PERIOD_ID = R.RPT_PERIOD_ID AND
-							E.NEEDS_EVAL_FLG = 'N' AND
-							E.MON_PLAN_ID = ESA.MON_PLAN_ID AND 
-							E.RPT_PERIOD_ID = ESA.RPT_PERIOD_ID AND
-							ESA.SUBMISSION_AVAILABILITY_CD IN ('GRANTED','REQUIRE') AND
-							M.MON_LOC_ID = T.MON_LOC_ID AND
-							(R.CALENDAR_YEAR > T.CALENDAR_YEAR OR 
-							(R.CALENDAR_YEAR = T.CALENDAR_YEAR AND R.QUARTER >= T.QUARTER)) AND
-							QA_CERT_EVENT_ID =vQceId;					
+		INSERT INTO tmpEmissionsStatus 
+			SELECT DISTINCT E.MON_PLAN_ID, E.RPT_PERIOD_ID
+				FROM camdecmps.EMISSION_EVALUATION E,
+				camdecmpsaux.EM_SUBMISSION_ACCESS ESA,
+				camdecmps.MONITOR_PLAN_LOCATION M, 
+				camdecmpsmd.REPORTING_PERIOD R,
+				(SELECT MON_LOC_ID, QA_CERT_EVENT_ID,
+					(SELECT EXTRACT('year' FROM qa_cert_event_date ) )AS CALENDAR_YEAR,
+					FLOOR((extract(month from QA_CERT_EVENT_DATE) + 2) / 3) AS QUARTER
+					FROM camdecmps.QA_CERT_EVENT) T
+				WHERE E.MON_PLAN_ID = M.MON_PLAN_ID AND 
+						E.RPT_PERIOD_ID = R.RPT_PERIOD_ID AND
+						E.NEEDS_EVAL_FLG = 'N' AND
+						E.MON_PLAN_ID = ESA.MON_PLAN_ID AND 
+						E.RPT_PERIOD_ID = ESA.RPT_PERIOD_ID AND
+						ESA.SUB_AVAILABILITY_CD IN ('GRANTED','REQUIRE') AND
+						M.MON_LOC_ID = T.MON_LOC_ID AND
+						(R.CALENDAR_YEAR > T.CALENDAR_YEAR OR 
+						(R.CALENDAR_YEAR = T.CALENDAR_YEAR AND R.QUARTER >= T.QUARTER)) AND
+						QA_CERT_EVENT_ID =vQceId;					
 
-			OPEN EM_CSR;	
-			  LOOP
-				FETCH NEXT FROM EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
-                  EXIT WHEN NOT FOUND;
-				   select * into result, error_msg 
-				   from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
-					IF result = 'F' then
-					 return;
-				    end if;
-				 RETURN NEXT;
-               END LOOP;
-			CLOSE EM_CSR;
+		OPEN EM_CSR;	
+		LOOP
+			FETCH NEXT FROM EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
+        EXIT WHEN NOT FOUND;
+		    select * into result, error_msg 
+		      from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
+            
+			if result = 'F' then
+                exit;
+			end if;
+        END LOOP;
+		CLOSE EM_CSR;
 				
-	  end if; --vSubmittable if
-   return;
+	end if; --vSubmittable if
+    
+    return next; -- Add row to return table.
 
 exception when others then
     get stacked diagnostics error_msg := message_text;
     result = 'F';
     error_msg :='From update_ecmps_status_for_qce_evaluation' ||' '|| error_msg;
 	
-   return;
+    return next; -- Add row to return table.
 END;
 $BODY$;

--- a/deployments/ecmps/release-v2.0-fix/Sprint13/6067/update_ecmps_status_for_tee_evaluation.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint13/6067/update_ecmps_status_for_tee_evaluation.sql
@@ -23,27 +23,28 @@ begin
     error_msg := '';
     result := 'T';
 	
- -- Remove check session for the record that are not the current check session. 
-	  DELETE FROM camdecmpswks.CHECK_SESSION 
-		WHERE TEST_EXTENSION_EXEMPTION_ID = vteeid
-		 AND  CHK_SESSION_ID != vchksessionid;	
+    -- Remove check session for the record that are not the current check session. 
+	DELETE FROM camdecmpswks.CHECK_SESSION 
+	 WHERE TEST_EXTENSION_EXEMPTION_ID = vteeid
+	   AND CHK_SESSION_ID != vchksessionid;	
 		 
-       UPDATE camdecmpswks.TEST_EXTENSION_EXEMPTION
-			SET NEEDS_EVAL_FLG	= 'N',	
-			    CHK_SESSION_ID = vchksessionid	
-		WHERE TEST_EXTENSION_EXEMPTION_ID = vteeid;
+    UPDATE camdecmpswks.TEST_EXTENSION_EXEMPTION
+	   SET NEEDS_EVAL_FLG	= 'N',	
+		   CHK_SESSION_ID = vchksessionid	
+	 WHERE TEST_EXTENSION_EXEMPTION_ID = vteeid;
 	 
-	  select  coalesce ( max( 'Y' ), 'N' ) as Submittable
-          into  vSubmittable
-         from  camdecmpswks.TEST_EXTENSION_EXEMPTION
-           where   TEST_EXTENSION_EXEMPTION_ID = vteeid
-            and  ( UPDATED_STATUS_FLG ='Y' or SUBMISSION_AVAILABILITY_CD = 'REQUIRE');			
+	select  coalesce ( max( 'Y' ), 'N' ) as Submittable
+      into  vSubmittable
+      from  camdecmpswks.TEST_EXTENSION_EXEMPTION
+     where   TEST_EXTENSION_EXEMPTION_ID = vteeid
+       and  ( UPDATED_STATUS_FLG ='Y' or SUBMISSION_AVAILABILITY_CD = 'REQUIRE');			
       
 	----------------------------------------------
-     IF vSubmittable = 'Y' then
-       create temp table camdecmpswks.tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+    if vSubmittable = 'Y' then
+        create temp table tmpEmissionsStatus(MON_PLAN_ID character varying,RPT_PERIOD_ID int);
+        
 		--	update EM evaluation
-		INSERT INTO camdecmpswks.tmpEmissionsStatus 
+		INSERT INTO tmpEmissionsStatus 
 			SELECT DISTINCT E.MON_PLAN_ID, E.RPT_PERIOD_ID
 					FROM camdecmpswks.EMISSION_EVALUATION E,
 					camdecmpsaux.EM_SUBMISSION_ACCESS ESA,
@@ -63,26 +64,27 @@ begin
 							(R.CALENDAR_YEAR = T.CALENDAR_YEAR AND R.QUARTER >= T.QUARTER))
 				  AND TEST_EXTENSION_EXEMPTION_ID =vteeid;
 							
-			OPEN EM_CSR;
-			  LOOP
-				FETCH NEXT FROM EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
-  				  EXIT WHEN NOT FOUND;
-				   select * into result, error_msg 
-				     from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
-					IF result = 'F' then
-					 return;
-				    end if;
-				  RETURN NEXT;
-				END LOOP;
-				CLOSE EM_CSR;	
-	 end if; --vSubmittable
-   return;
+		OPEN EM_CSR;
+		LOOP
+			FETCH NEXT FROM EM_CSR INTO V_MON_PLAN_ID, V_RPT_PERIOD_ID;
+  		EXIT WHEN NOT FOUND;
+		    select * into result, error_msg 
+		      from camdecmpswks.delete_calculated_em_data_from_workspace(V_MON_PLAN_ID, V_RPT_PERIOD_ID);	
+			
+            if result = 'F' then
+                exit;
+			end if;
+		END LOOP;
+		CLOSE EM_CSR;	
+	end if; --vSubmittable
+    
+    return next; -- Add row to return table.
 
 exception when others then
     get stacked diagnostics error_msg := message_text;
     result = 'F';
     error_msg :='From update_ecmps_status_for_tee_evaluation' ||' '|| error_msg;
 	
-   return;
+    return next; -- Add row to return table.
 END;
 $BODY$;


### PR DESCRIPTION
- Change return to return-next including changing return to next in loops and removing excess return-next.
- Removed camdecmpswks schema prefix from "create temp table" statements.
- Replace EM_SUBMISSION_ACCESS SUBMISSION_AVAILABILITY_CD with SUB_AVAILABILITY_CD.