### PR TITLE
#6266 Changes to delete un-submitted MP Data in the workspace when a …

### DIFF
--- a/camdecmpswks/procedures/delete_monitor_plan_data_from_workspace.sql
+++ b/camdecmpswks/procedures/delete_monitor_plan_data_from_workspace.sql
@@ -55,6 +55,44 @@ BEGIN
 	DELETE FROM camdecmpswks.monitor_location
 	WHERE mon_loc_id = ANY(monLocIds)
     AND mon_loc_id != ALL(otherMpMonLocIds);
+	
+    -- Delete monitor location children for locations that are used in other monitor plans.
+	-- Helps ensure that workspace only monitor location children are deleted from the workspace.
+	DELETE FROM camdecmpswks.MATS_METHOD_DATA 			 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);	
+	DELETE FROM camdecmpswks.MONITOR_DEFAULT 			 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);	
+	DELETE FROM camdecmpswks.MONITOR_FORMULA 			 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);
+	DELETE FROM camdecmpswks.MONITOR_LOAD 				 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);
+	DELETE FROM camdecmpswks.MONITOR_LOCATION_ATTRIBUTE  WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);
+	DELETE FROM camdecmpswks.MONITOR_METHOD 			 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);
+	DELETE FROM camdecmpswks.MONITOR_QUALIFICATION 		 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);
+	DELETE FROM camdecmpswks.MONITOR_SPAN 				 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);
+	DELETE FROM camdecmpswks.RECT_DUCT_WAF 				 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);  
+	
+    -- Delete component or system for locations that are used in other monitor plans and are not used in supplemental data.
+	-- The supplemental data for the target MP should have been deleted by delete_monitor_plan_emissions_data_from_workspace.
+	-- If supplemental data exists for another MP, the coponent or system should not be new.
+	-- Helps ensure that workspace only monitor location children are deleted from the workspace.
+	DELETE 
+      FROM 	camdecmpswks.COMPONENT dat
+     WHERE  mon_loc_id = ANY(monLocIds)
+       AND 	mon_loc_id = ANY(otherMpMonLocIds)
+       AND  NOT EXISTS
+			( 
+				SELECT 	1
+				  FROM 	camdecmpswks.COMPONENT_OP_SUPP_DATA exs
+				 WHERE 	exs.COMPONENT_ID = dat.COMPONENT_ID
+			);
+	DELETE
+      FROM 	camdecmpswks.MONITOR_SYSTEM dat
+     WHERE  mon_loc_id = ANY(monLocIds)
+       AND 	mon_loc_id = ANY(otherMpMonLocIds)
+       AND  NOT EXISTS
+			( 
+				SELECT 	1
+				  FROM 	camdecmpswks.SYSTEM_OP_SUPP_DATA exs
+				 WHERE 	exs.MON_SYS_ID = dat.MON_SYS_ID
+			);
+    
 
 	DELETE FROM camdecmpswks.monitor_plan
 	WHERE mon_plan_id = monPlanId;

--- a/deployments/ecmps/release-v2.0-fix/Sprint14/6266/delete_monitor_plan_data_from_workspace.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint14/6266/delete_monitor_plan_data_from_workspace.sql
@@ -55,6 +55,44 @@ BEGIN
 	DELETE FROM camdecmpswks.monitor_location
 	WHERE mon_loc_id = ANY(monLocIds)
     AND mon_loc_id != ALL(otherMpMonLocIds);
+	
+    -- Delete monitor location children for locations that are used in other monitor plans.
+	-- Helps ensure that workspace only monitor location children are deleted from the workspace.
+	DELETE FROM camdecmpswks.MATS_METHOD_DATA 			 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);	
+	DELETE FROM camdecmpswks.MONITOR_DEFAULT 			 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);	
+	DELETE FROM camdecmpswks.MONITOR_FORMULA 			 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);
+	DELETE FROM camdecmpswks.MONITOR_LOAD 				 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);
+	DELETE FROM camdecmpswks.MONITOR_LOCATION_ATTRIBUTE  WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);
+	DELETE FROM camdecmpswks.MONITOR_METHOD 			 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);
+	DELETE FROM camdecmpswks.MONITOR_QUALIFICATION 		 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);
+	DELETE FROM camdecmpswks.MONITOR_SPAN 				 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);
+	DELETE FROM camdecmpswks.RECT_DUCT_WAF 				 WHERE mon_loc_id = ANY(monLocIds) AND mon_loc_id = ANY(otherMpMonLocIds);  
+	
+    -- Delete component or system for locations that are used in other monitor plans and are not used in supplemental data.
+	-- The supplemental data for the target MP should have been deleted by delete_monitor_plan_emissions_data_from_workspace.
+	-- If supplemental data exists for another MP, the coponent or system should not be new.
+	-- Helps ensure that workspace only monitor location children are deleted from the workspace.
+	DELETE 
+      FROM 	camdecmpswks.COMPONENT dat
+     WHERE  mon_loc_id = ANY(monLocIds)
+       AND 	mon_loc_id = ANY(otherMpMonLocIds)
+       AND  NOT EXISTS
+			( 
+				SELECT 	1
+				  FROM 	camdecmpswks.COMPONENT_OP_SUPP_DATA exs
+				 WHERE 	exs.COMPONENT_ID = dat.COMPONENT_ID
+			);
+	DELETE
+      FROM 	camdecmpswks.MONITOR_SYSTEM dat
+     WHERE  mon_loc_id = ANY(monLocIds)
+       AND 	mon_loc_id = ANY(otherMpMonLocIds)
+       AND  NOT EXISTS
+			( 
+				SELECT 	1
+				  FROM 	camdecmpswks.SYSTEM_OP_SUPP_DATA exs
+				 WHERE 	exs.MON_SYS_ID = dat.MON_SYS_ID
+			);
+    
 
 	DELETE FROM camdecmpswks.monitor_plan
 	WHERE mon_plan_id = monPlanId;


### PR DESCRIPTION
## Removing new MP child records when MP is reverted.

Currently when a monitor location belongs to multiple MP, it is not deleted and therefore the cascade deletes to the monitor location's children do not occur.  This is not a problem if the children exist in official since they will be overwritten during the revert process, but if they are new records in the workspace they should be deleted.

To resolve this problem, when the revert process skips deleting a monitor location, it should explicitly delete its children.

Note that Component and System rows may have foreign key constraints in the Component and System Op Supp Data tables respectively, which the deletes will need to handle.  This supplemental data should have already been deleted if it exists because of the "target" MP.  If a record exists in the supplemental tables then the component or system is "presumably" not new, does not have to be deleted, and should be updated when the MP is copied back into the workspace.

### Affected Code

- camdecmpswks.**delete_monitor_plan_data_from_workspace**

### Monitor Location Child Tables
- component
- mats_method_data
- monitor_default
- monitor_formula
- monitor_load
- monitor_location_attribute
- monitor_method
- monitor_qualification
- monitor_span
- monitor_system
- rect_duct_waf

Note that "**monitor_system_component**" has cascade delete foreign keys to both "**component**" and "**monitor_system**", so it does not require explicit handling.
