### PR TITLE
feat(6110): added MATS Report Type master data

### DIFF
--- a/deployments/ecmps/release-v2.0-fix/Sprint18/6110/load-master-data-definitions.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint18/6110/load-master-data-definitions.sql
@@ -1,0 +1,29 @@
+DO $$
+DECLARE
+	groupCode text := 'MDM';
+	datasetCode text;
+	datatableId integer;
+BEGIN
+    /***** MATS Report Type Codes & Descriptions *****/
+----------------------------------------------------------------------------------------------------------------------------
+    datasetCode := 'mats-report-type-codes';
+
+	DELETE FROM camdaux.dataset WHERE group_cd = groupCode AND dataset_cd = datasetCode;
+    DELETE FROM camdaux.datatable WHERE dataset_cd = datasetCode;
+    DELETE FROM camdaux.datacolumn WHERE name = ANY (ARRAY['mats_rpt_type_cd', 'mats_rpt_type_description', 'metadata_rpt_type_cd', 'requires_pollutant', 'requires_test_method']);
+
+    INSERT INTO camdaux.dataset(dataset_cd, group_cd, display_name)
+    VALUES (datasetCode, 'MDM', 'MATS Report Type Codes & Descriptions');
+
+	/***** DATATABLE 1 *****/
+	INSERT INTO camdaux.datatable(dataset_cd, table_order, display_name, sql_statement)
+	VALUES(datasetCode, 1, 'MATS Report Type Codes & Descriptions', 'SELECT * FROM camdecmpsmd.mats_report_type_code')
+	RETURNING datatable_id INTO datatableId;
+
+	/***** COLUMNS *****/
+	INSERT INTO camdaux.datacolumn(datatable_id, column_order, name, alias, display_name)
+	VALUES
+		(datatableId, 1, 'mats_rpt_type_cd', 'matsReportTypeCode', 'MATS Report Type Code'),
+		(datatableId, 2, 'mats_rpt_type_description', 'matsReportTypeDescription', 'MATS Report Type Description');
+END $$;
+

--- a/deployments/ecmps/release-v2.0/load-master-data-definitions.sql
+++ b/deployments/ecmps/release-v2.0/load-master-data-definitions.sql
@@ -1106,4 +1106,19 @@ BEGIN
 		(datatableId, 3, 'activation_date', 'activationDate', 'Vendor Activation Date'),
 		(datatableId, 4, 'deactivation_date', 'deactivationDate', 'Vendor Deactivation Date'),
 		(datatableId, 5, 'active_ind', 'activeIndicator', 'Active');
+----------------------------------------------------------------------------------------------------------------------------
+    datasetCode := 'mats-report-type-codes';
+    INSERT INTO camdaux.dataset(dataset_cd, group_cd, display_name)
+    VALUES (datasetCode, 'MDM', 'MATS Report Type Codes & Descriptions');
+
+	/***** DATATABLE 1 *****/
+	INSERT INTO camdaux.datatable(dataset_cd, table_order, display_name, sql_statement)
+	VALUES(datasetCode, 1, 'MATS Report Type Codes & Descriptions', 'SELECT * FROM camdecmpsmd.mats_report_type_code')
+	RETURNING datatable_id INTO datatableId;
+
+	/***** COLUMNS *****/
+	INSERT INTO camdaux.datacolumn(datatable_id, column_order, name, alias, display_name)
+	VALUES
+		(datatableId, 1, 'mats_rpt_type_cd', 'matsReportTypeCode', 'MATS Report Type Code'),
+		(datatableId, 2, 'mats_rpt_type_description', 'matsReportTypeDescription', 'MATS Report Type Description');
 END $$;


### PR DESCRIPTION
## Related Issues

- [#6110](https://github.com/US-EPA-CAMD/easey-ui/issues/6110)

## Main Changes

- Added the master data definitions for MATS Report Type Codes, used in the ECMPS UI Mats Data Submission "Report Type" dropdown select input.