### PR TITLE
Fix/6612 MP revert error

### DIFF
--- a/camdecmpswks/constraints-indexes/3-operating_supp_data.sql
+++ b/camdecmpswks/constraints-indexes/3-operating_supp_data.sql
@@ -3,7 +3,8 @@ ALTER TABLE IF EXISTS camdecmpswks.operating_supp_data
     ADD CONSTRAINT fk_operating_supp_data_fuel_code FOREIGN KEY (fuel_cd)
         REFERENCES camdecmpsmd.fuel_code (fuel_cd) MATCH SIMPLE,
     ADD CONSTRAINT fk_operating_supp_data_monitor_location FOREIGN KEY (mon_loc_id)
-        REFERENCES camdecmpswks.monitor_location (mon_loc_id) MATCH SIMPLE,
+        REFERENCES camdecmpswks.monitor_location (mon_loc_id) MATCH SIMPLE
+        ON DELETE CASCADE,
     ADD CONSTRAINT fk_operating_supp_data_operating_type_code FOREIGN KEY (op_type_cd)
         REFERENCES camdecmpsmd.operating_type_code (op_type_cd) MATCH SIMPLE,
     ADD CONSTRAINT fk_operating_supp_data_reporting_period FOREIGN KEY (rpt_period_id)

--- a/deployments/ecmps/release-v2.0-fix/Sprint19/6612/camdecmpswks/constraints-indexes/3-operating_supp_data.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint19/6612/camdecmpswks/constraints-indexes/3-operating_supp_data.sql
@@ -1,0 +1,8 @@
+ALTER TABLE IF EXISTS camdecmpswks.operating_supp_data
+    DROP CONSTRAINT fk_operating_supp_data_monitor_location;
+
+ALTER TABLE IF EXISTS camdecmpswks.operating_supp_data
+    ADD CONSTRAINT fk_operating_supp_data_monitor_location FOREIGN KEY (mon_loc_id)
+        REFERENCES camdecmpswks.monitor_location (mon_loc_id) MATCH SIMPLE
+        ON DELETE CASCADE;
+


### PR DESCRIPTION
## Related Issues:

- [#6612](https://github.com/US-EPA-CAMD/easey-ui/issues/6612)

## Main Changes:

- Added a missing `ON DELETE CASCADE` clause to the **`camdecmpswks.operating_supp_data`** foreign key constraint that references the **`camdecmpswks.monitor_location`** table. This data is copied back into the workspace in the `camdecmpswks.copy_monitor_plan_emissions_data_to_workspace()` procedure.