### PR TITLE
MATS 2.0 Needed CPMS Crosscheck and Lookup Changes #6257

### DIFF
--- a/camdecmpsmd/table-data/component_type_code.sql
+++ b/camdecmpsmd/table-data/component_type_code.sql
@@ -25,6 +25,5 @@ INSERT INTO camdecmpsmd.component_type_code (component_type_cd, component_type_c
 INSERT INTO camdecmpsmd.component_type_code (component_type_cd, component_type_cd_description, span_indicator, parameter_cd) VALUES ('HCL', 'HCl Concentration Analyzer', 1, 'HCLC');
 INSERT INTO camdecmpsmd.component_type_code (component_type_cd, component_type_cd_description, span_indicator, parameter_cd) VALUES ('HF', 'HF Concentration Analyzer', NULL, 'HFC');
 INSERT INTO camdecmpsmd.component_type_code (component_type_cd, component_type_cd_description, span_indicator, parameter_cd) VALUES ('STRAIN', 'Sorbent Trap Sampling Train Component, consisting of a sample gas flow meter and the associated sorbent trap', NULL, 'HG');
-INSERT INTO camdecmpsmd.component_type_code (component_type_cd, component_type_cd_description, span_indicator, parameter_cd) VALUES ('CPM', 'PM Continuous Parametric Monitor', NULL, 'PMCO');
 INSERT INTO camdecmpsmd.component_type_code (component_type_cd, component_type_cd_description, span_indicator, parameter_cd) VALUES ('PM', 'Particulate Matter Analyzer', NULL, 'PMC');
 

--- a/camdecmpsmd/table-data/cross_check_catalog_value.sql
+++ b/camdecmpsmd/table-data/cross_check_catalog_value.sql
@@ -1368,10 +1368,8 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1644, 16, 'HGRE', NULL, 'MS-2');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1645, 16, 'SO2RE', NULL, 'MS-2');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1646, 37, 'RATA', 'ConfidenceCoefficientUGSCM', '0.1');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8014, 15, 'CPMS', 'CPM', 'Yes');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8015, 17, 'PM', 'PMRE', 'PMRE/CEM');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8016, 17, 'PM', 'PMRH', 'PMRH/CEM');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8017, 14, 'CPMS', 'NFS', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8018, 85, 'PM', 'PMRE,PMRH,PMPMA,PMPMC,PM', 'PMRE (or PMRH, PMPMA, PMPMC version for heat input based method or PM Supplemental Method)');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8019, 85, 'MATS', 'HGRE,HGRH,HCLRE,HCLRH,HFRE,HFRH,SO2RE,SO2RH,MATSSUP', 'HGRE, HCLRE or HFRE method (or HGRH, HCLRH or HFRH versions for heat input based method, or equivalent SO2RE or SO2RH method, or Supplemental Method)');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1361, 85, 'HCL', 'HCLRE,HCLRH,SO2RE,SO2RH,HCL', 'HCLRE (or HCLRH version for heat input based method, or equivalent SO2 method, or HCL Supplemental Method)');
@@ -1455,7 +1453,6 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8094, 190, 'HF', 'W', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8095, 190, 'FLOW', 'W', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8096, 190, 'STRAIN', 'D', NULL);
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8097, 21, 'CPM', NULL, NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8098, 21, 'HG', 'W', 'DIL');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8099, 21, 'HG', 'W', 'DIN');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8100, 21, 'HG', 'W', 'DOU');
@@ -2315,17 +2312,11 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8952, 197, 'H', 'LOAD', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8953, 11, 'PMRE', 'METHOD', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8954, 11, 'PMRH', 'METHOD', NULL);
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8955, 11, 'PMPMA', 'METHOD', NULL);
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8956, 11, 'PMPMC', 'METHOD', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8957, 8, 'NOX', 'CALC', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8958, 8, 'PMRE', 'CEM', 'PM');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8959, 8, 'PMRE', 'CALC', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8960, 8, 'PMRH', 'CEM', 'PM');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8961, 8, 'PMRH', 'CALC', NULL);
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8962, 8, 'PMPMA', 'CPMS', 'CPMS');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8963, 8, 'PMPMA', 'CALC', NULL);
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8964, 8, 'PMPMC', 'CPMS', 'CPMS');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8965, 8, 'PMPMC', 'CALC', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8966, 198, 'CO2', 'FSP75', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8967, 198, 'CO2', 'FSP75C', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (8968, 198, 'CO2', 'SPTS', NULL);

--- a/camdecmpsmd/table-data/method_code.sql
+++ b/camdecmpsmd/table-data/method_code.sql
@@ -22,5 +22,4 @@ INSERT INTO camdecmpsmd.method_code (method_cd, method_cd_description) VALUES ('
 INSERT INTO camdecmpsmd.method_code (method_cd, method_cd_description) VALUES ('PEM', 'Predictive Emissions Monitor');
 INSERT INTO camdecmpsmd.method_code (method_cd, method_cd_description) VALUES ('CEMST', 'Hg CEMS and Sorbent Trap Monitoring System');
 INSERT INTO camdecmpsmd.method_code (method_cd, method_cd_description) VALUES ('ST', 'Sorbent Trap Monitoring System');
-INSERT INTO camdecmpsmd.method_code (method_cd, method_cd_description) VALUES ('CPMS', 'PM Continuous Parametric Monitoring System');
 

--- a/camdecmpsmd/table-data/qual_type_code.sql
+++ b/camdecmpsmd/table-data/qual_type_code.sql
@@ -9,4 +9,3 @@ INSERT INTO camdecmpsmd.qual_type_code (qual_type_cd, qual_type_cd_description, 
 INSERT INTO camdecmpsmd.qual_type_code (qual_type_cd, qual_type_cd_description, qual_type_group_cd) VALUES ('PRATA1', 'Single-Level RATA (Petition Approved)', 'OTHR');
 INSERT INTO camdecmpsmd.qual_type_code (qual_type_cd, qual_type_cd_description, qual_type_group_cd) VALUES ('PRATA2', 'Two-Level RATA (Petition Approved)', 'OTHR');
 INSERT INTO camdecmpsmd.qual_type_code (qual_type_cd, qual_type_cd_description, qual_type_group_cd) VALUES ('HGAVG', 'MATS Hg Averaging Group', 'OTHR');
-INSERT INTO camdecmpsmd.qual_type_code (qual_type_cd, qual_type_cd_description, qual_type_group_cd) VALUES ('CPMS', 'PM CPMS System operating limit', 'CPMS');

--- a/camdecmpsmd/table-data/system_type_code.sql
+++ b/camdecmpsmd/table-data/system_type_code.sql
@@ -20,4 +20,3 @@ INSERT INTO camdecmpsmd.system_type_code (sys_type_cd, sys_type_description, par
 INSERT INTO camdecmpsmd.system_type_code (sys_type_cd, sys_type_description, parameter_cd) VALUES ('HCL', 'HCl Concentration CEMS', 'HCL');
 INSERT INTO camdecmpsmd.system_type_code (sys_type_cd, sys_type_description, parameter_cd) VALUES ('HF', 'HF Concentration CEMS', 'HF');
 INSERT INTO camdecmpsmd.system_type_code (sys_type_cd, sys_type_description, parameter_cd) VALUES ('ST', 'Sorbent Trap Monitoring System', 'HG');
-INSERT INTO camdecmpsmd.system_type_code (sys_type_cd, sys_type_description, parameter_cd) VALUES ('CPMS', 'Particulate Matter Parametric Monitoring System', 'PMCO');

--- a/deployments/ecmps/release-v2.0-fix/Sprint19/6257/script/updateCrosscheckAndLookupChanges.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint19/6257/script/updateCrosscheckAndLookupChanges.sql
@@ -1,0 +1,42 @@
+
+DELETE FROM camdecmpsmd.cross_check_catalog_value
+WHERE cross_chk_catalog_id = 21
+  AND value1 = 'CPM';
+
+--Remove rows with Method Parameter Code equal to "PMPMA" or "PMPMC"
+DELETE FROM camdecmpsmd.cross_check_catalog_value
+WHERE cross_chk_catalog_id = 8
+  AND value1 in ('PMPMA,PMPMC');
+
+--Remove row for Parameter Code: "PMPMA", Category Code: "METHOD"
+--Remove row for Parameter Code "PMPMC", Category Code: "METHOD"
+DELETE FROM camdecmpsmd.cross_check_catalog_value
+WHERE cross_chk_catalog_id = 11
+  AND value1 in ('PMPMA,PMPMC')
+  AND value2 = 'METHOD';
+
+--Remove row with System Type Code equal to "CPMS"
+DELETE FROM camdecmpsmd.cross_check_catalog_value
+WHERE cross_chk_catalog_id = 15
+  AND value1 = 'CPMS';
+
+--Remove row with System Type Code equal to "CPMS"
+DELETE FROM camdecmpsmd.cross_check_catalog_value
+WHERE cross_chk_catalog_id = 14
+  AND value1 = 'CPMS';
+
+--Remove row for Component Type Code "CPM"
+DELETE FROM camdecmpsmd.component_type_code
+WHERE component_type_cd = 'CPM';
+
+--Remove row for Method Code "CPMS"
+DELETE FROM camdecmpsmd.method_code
+WHERE method_cd = 'CPMS';
+
+--Remove row for Qualification Type Code "CPMS"
+DELETE FROM camdecmpsmd.qual_type_code
+WHERE qual_type_cd = 'CPMS';
+
+--Remove row for System Type Code "CPMS"
+DELETE FROM camdecmpsmd.system_type_code
+WHERE sys_type_cd = 'CPMS';

--- a/deployments/ecmps/release-v2.0-fix/Sprint19/6257/script/updateCrosscheckAndLookupChanges.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint19/6257/script/updateCrosscheckAndLookupChanges.sql
@@ -34,6 +34,7 @@ DELETE FROM camdecmpsmd.method_code
 WHERE method_cd = 'CPMS';
 
 --Remove row for Qualification Type Code "CPMS"
+DELETE FROM camdecmps.monitor_qualification where qual_type_cd  = 'CPMS';
 DELETE FROM camdecmpsmd.qual_type_code
 WHERE qual_type_cd = 'CPMS';
 


### PR DESCRIPTION
Ticket
https://github.com/US-EPA-CAMD/easey-ui/issues/6257

changes
update the table-data scripts to remove the inserts for the rows that should not be there and also include a script in a deployments\ecmps\release-v2.0-fix\Sprint19\6257 that includes delete statements and update records.