### PR TITLE
To update the `eval_status_cd` value from 'ERR' to 'INFO' for `CRIT2` and `CRIT3` (Step needed for #6629)

### DIFF
--- a/deployments/ecmps/release-v2.0-fix/Sprint19/6629/camdecmpsmd/script/udpate_severity_cd_CRIT2_CRIT3_to_INFO.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint19/6629/camdecmpsmd/script/udpate_severity_cd_CRIT2_CRIT3_to_INFO.sql
@@ -1,0 +1,3 @@
+UPDATE camdecmpsmd.severity_code
+SET eval_status_cd = 'INFO'
+WHERE severity_cd IN ('CRIT2', 'CRIT3');


### PR DESCRIPTION
### Changes Made:
- To update the `eval_status_cd` value from 'ERR' to 'INFO' for severity codes `CRIT2` and `CRIT3` in the `camdecmpsmd.severity_code` table.
- Reference to #6629 & #6539 - based on the final agreed approach to correct issue for CRIT2. 