### PR TITLE
add the missing op_year record AND an update create_partitions to ins…

### DIFF
--- a/camddmw/procedures/create_partitions.sql
+++ b/camddmw/procedures/create_partitions.sql
@@ -49,6 +49,14 @@ BEGIN
 	IF executeFlag = 'Y' THEN
 		EXECUTE cmdStmt;
 		RAISE NOTICE '-- executed --';
+		EXECUTE format('SELECT COUNT(*) FROM camddmw.op_year WHERE op_year = %s', year) 
+        INTO op_year_count;
+		IF op_year_count = 0 THEN
+            EXECUTE format('
+                INSERT INTO camddmw.op_year (op_year, archive_ind, hourly_data_ind)
+                VALUES (%s, 0, 1)', year);
+            RAISE NOTICE '-- Added op_year record for year % --', year;
+		END IF;
 	END IF;
 
 -------------------------------------------------------------------------------------------------------------------

--- a/camddmw/procedures/create_partitions.sql
+++ b/camddmw/procedures/create_partitions.sql
@@ -49,6 +49,10 @@ BEGIN
 	IF executeFlag = 'Y' THEN
 		EXECUTE cmdStmt;
 		RAISE NOTICE '-- executed --';
+	END IF;
+	
+	-- Separately check and insert op_year record
+	IF executeFlag = 'Y' THEN
 		EXECUTE format('SELECT COUNT(*) FROM camddmw.op_year WHERE op_year = %s', year) 
         INTO op_year_count;
 		IF op_year_count = 0 THEN

--- a/camddmw/procedures/create_partitions.sql
+++ b/camddmw/procedures/create_partitions.sql
@@ -51,16 +51,11 @@ BEGIN
 		RAISE NOTICE '-- executed --';
 	END IF;
 	
-	-- Separately check and insert op_year record
+	cmdStmt := format('INSERT INTO camddmw.op_year (op_year, archive_ind, hourly_data_ind) VALUES (%s, 0, 1)', year);
+	RAISE NOTICE '%', cmdStmt;
 	IF executeFlag = 'Y' THEN
-		EXECUTE format('SELECT COUNT(*) FROM camddmw.op_year WHERE op_year = %s', year) 
-        INTO op_year_count;
-		IF op_year_count = 0 THEN
-            EXECUTE format('
-                INSERT INTO camddmw.op_year (op_year, archive_ind, hourly_data_ind)
-                VALUES (%s, 0, 1)', year);
-            RAISE NOTICE '-- Added op_year record for year % --', year;
-		END IF;
+		EXECUTE cmdStmt;
+		RAISE NOTICE '-- executed --';
 	END IF;
 
 -------------------------------------------------------------------------------------------------------------------

--- a/deployments/campd/release-v1.8-fix/6665/camddmw/add_missing_op_year.sql
+++ b/deployments/campd/release-v1.8-fix/6665/camddmw/add_missing_op_year.sql
@@ -1,0 +1,2 @@
+INSERT INTO camddmw.op_year (op_year, archive_ind, hourly_data_ind)
+VALUES (2025, 0, 1);

--- a/deployments/campd/release-v1.8-fix/6665/camddmw/procedures/create_partitions.sql
+++ b/deployments/campd/release-v1.8-fix/6665/camddmw/procedures/create_partitions.sql
@@ -1,0 +1,315 @@
+-- PROCEDURE: camddmw.create_partitions(integer, character)
+
+-- DROP PROCEDURE IF EXISTS camddmw.create_partitions(integer, character);
+
+CREATE OR REPLACE PROCEDURE camddmw.create_partitions(
+	IN year integer,
+	IN executeflag character DEFAULT 'N'::bpchar)
+LANGUAGE 'plpgsql'
+AS $BODY$
+
+DECLARE
+	counter integer;
+	toDate date;
+	fromDate date;
+	cmdStmt text;
+	tableName text;
+	partitionName text;
+	partitionNumber integer;
+	partitionExpression text;
+	schemaName text := 'camddmw';
+BEGIN
+	IF executeFlag = 'N' THEN
+		RAISE NOTICE 'The executeFlag is set to ''N'' so partitions will not be created. DRY RUN ONLY! Set executeFlag to ''Y'' to create partitions.';
+	END IF;	
+
+	--NEED TO DISCUSS HOW FAR OUT TO CREATE THESE
+	--camddmw.allowance_holding_dim
+	--CONSTRAINT allowance_holding_dim_all_hold_dim_p66_pkey PRIMARY KEY (vintage_year, prg_code, start_block)
+	--FOR VALUES FROM ('2060') TO ('2061')
+
+ 	-- Check if partition table of previous year exits
+     IF executeFlag = 'Y' THEN
+        tableName:= 'day_unit_data_dm_em_ud_'||year-1||'w01';
+	   --RAISE NOTICE '%', tableName;
+	 EXECUTE format('SELECT count(*) FROM pg_tables WHERE schemaname=%L and tablename =%L;', schemaName, tableName)
+	    into counter;
+	   IF counter=0 THEN
+		  executeFlag = 'F';
+		  RAISE NOTICE '--Error: no partition tables found for previous year --';
+		  Return;
+	   END IF;
+    end if;
+
+-------------------------------------------------------------------------------------------------------------------
+	tableName := schemaName || '.annual_unit_data';
+	cmdStmt := format('CREATE TABLE IF NOT EXISTS %s_dm_em_ua_%s PARTITION OF %s
+				    FOR VALUES FROM (%L) TO (%L);', tableName, year, tableName, year, year+1);
+	RAISE NOTICE '%', cmdStmt;
+	IF executeFlag = 'Y' THEN
+		EXECUTE cmdStmt;
+		RAISE NOTICE '-- executed --';
+		EXECUTE format('SELECT COUNT(*) FROM camddmw.op_year WHERE op_year = %s', year) 
+        INTO op_year_count;
+		IF op_year_count = 0 THEN
+            EXECUTE format('
+                INSERT INTO camddmw.op_year (op_year, archive_ind, hourly_data_ind)
+                VALUES (%s, 0, 1)', year);
+            RAISE NOTICE '-- Added op_year record for year % --', year;
+		END IF;
+	END IF;
+
+-------------------------------------------------------------------------------------------------------------------
+	tableName := 'allowance_holding_dim';
+	partitionName := tableName || '_all_hold_dim_p';
+	EXECUTE format('
+		SELECT MAX(CAST(REPLACE(table_name, %L, %L) AS integer))
+		FROM information_schema.tables
+		WHERE table_name like ''%s%%'';
+	', partitionName, '', partitionName) INTO partitionNumber;
+	cmdStmt := format('CREATE TABLE IF NOT EXISTS %s.%s%s PARTITION OF %s.%s
+				    FOR VALUES FROM (%L) TO (%L);', schemaName, partitionName, partitionNumber+1, schemaName, tableName, year+30, year+31);
+	RAISE NOTICE '%', cmdStmt;
+	IF executeFlag = 'Y' THEN
+		EXECUTE cmdStmt;
+		RAISE NOTICE '-- executed --';
+	END IF;	
+
+-------------------------------------------------------------------------------------------------------------------
+	tableName := 'rep_year_dim';
+	partitionName := tableName || '_rep_year_dm_p';
+	EXECUTE format('
+		SELECT MAX(CAST(REPLACE(table_name, %L, %L) AS integer))
+		FROM information_schema.tables
+		WHERE table_name like ''%s%%'';
+	', partitionName, '', partitionName) INTO partitionNumber;
+	cmdStmt := format('CREATE TABLE IF NOT EXISTS %s.%s%s PARTITION OF %s.%s
+				    FOR VALUES FROM (%L) TO (%L);', schemaName, partitionName, partitionNumber+1, schemaName, tableName, year, year+1);
+	RAISE NOTICE '%', cmdStmt;
+	IF executeFlag = 'Y' THEN
+		EXECUTE cmdStmt;
+		RAISE NOTICE '-- executed --';
+	END IF;	
+-------------------------------------------------------------------------------------------------------------------
+	tableName := 'control_year_dim';
+	partitionName := tableName || '_cntrl_yr_dim_p';
+	EXECUTE format('
+		SELECT MAX(CAST(REPLACE(table_name, %L, %L) AS integer))
+		FROM information_schema.tables
+		WHERE table_name like ''%s%%'';
+	', partitionName, '', partitionName) INTO partitionNumber;
+	cmdStmt := format('CREATE TABLE IF NOT EXISTS %s.%s%s PARTITION OF %s.%s
+				    FOR VALUES FROM (%L) TO (%L);', schemaName, partitionName, partitionNumber+1, schemaName, tableName, year, year+1);
+	RAISE NOTICE '%', cmdStmt;
+	IF executeFlag = 'Y' THEN
+		EXECUTE cmdStmt;
+		RAISE NOTICE '-- executed --';
+	END IF;
+
+-------------------------------------------------------------------------------------------------------------------
+	counter := 0;
+	tableName := schemaName || '.day_unit_data';
+	EXECUTE format('
+		SELECT pg_get_expr(pt.relpartbound, pt.oid, true)
+		FROM pg_class base_tb 
+		JOIN pg_inherits i on i.inhparent = base_tb.oid
+		JOIN pg_class pt on pt.oid = i.inhrelid
+		WHERE base_tb.oid = %L::regclass
+		ORDER BY pt.relname DESC
+		LIMIT 1;
+	', tableName) INTO partitionExpression;
+	
+	toDate := SUBSTRING(partitionExpression, 37, 10);
+
+	LOOP
+		fromDate := toDate;
+		counter := counter + 1;
+		toDate := fromDate + INTERVAL '7 days';
+
+		cmdStmt := format('CREATE TABLE IF NOT EXISTS %s_dm_em_ud_%sw%s PARTITION OF %s
+			FOR VALUES FROM (%L) TO (%L);', tableName, year, LPAD(CAST(counter AS text), 2, '0'), tableName, fromDate, toDate);
+		RAISE NOTICE '%', cmdStmt;
+		IF executeFlag = 'Y' THEN
+			EXECUTE cmdStmt;
+			RAISE NOTICE '-- executed --';
+		END IF;
+
+		EXIT WHEN date_part('year', toDate) = year+1;
+	END LOOP;
+
+-------------------------------------------------------------------------------------------------------------------
+	tableName := 'fuel_year_dim';
+	partitionName := tableName || '_fuel_yr_dim_p';
+	EXECUTE format('
+		SELECT MAX(CAST(REPLACE(table_name, %L, %L) AS integer))
+		FROM information_schema.tables
+		WHERE table_name like ''%s%%'';
+	', partitionName, '', partitionName) INTO partitionNumber;
+	cmdStmt := format('CREATE TABLE IF NOT EXISTS %s.%s%s PARTITION OF %s.%s
+				    FOR VALUES FROM (%L) TO (%L);', schemaName, partitionName, partitionNumber+1, schemaName, tableName, year, year+1);
+	RAISE NOTICE '%', cmdStmt;
+	IF executeFlag = 'Y' THEN
+		EXECUTE cmdStmt;
+		RAISE NOTICE '-- executed --';
+	END IF;
+
+-------------------------------------------------------------------------------------------------------------------
+	counter := 0;
+	tableName := schemaName || '.hour_unit_data';
+	EXECUTE format('
+		SELECT pg_get_expr(pt.relpartbound, pt.oid, true)
+		FROM pg_class base_tb 
+		JOIN pg_inherits i on i.inhparent = base_tb.oid
+		JOIN pg_class pt on pt.oid = i.inhrelid
+		WHERE base_tb.oid = %L::regclass
+		ORDER BY pt.relname DESC
+		LIMIT 1;
+	', tableName) INTO partitionExpression;
+	
+	toDate := SUBSTRING(partitionExpression, 37, 10);
+
+	LOOP
+		fromDate := toDate;
+		counter := counter + 1;
+		toDate := fromDate + INTERVAL '7 days';
+
+		cmdStmt := format('CREATE TABLE IF NOT EXISTS %s_dm_em_uh_%sw%s PARTITION OF %s
+			FOR VALUES FROM (%L) TO (%L);', tableName, year, LPAD(CAST(counter AS text), 2, '0'), tableName, fromDate, toDate);
+		RAISE NOTICE '%', cmdStmt;
+		IF executeFlag = 'Y' THEN
+			EXECUTE cmdStmt;
+			RAISE NOTICE '-- executed --';
+		END IF;
+
+		EXIT WHEN date_part('year', toDate) = year+1;
+	END LOOP;
+
+-------------------------------------------------------------------------------------------------------------------
+	counter := 0;
+	tableName := schemaName || '.hour_unit_mats_data';
+	EXECUTE format('
+		SELECT pg_get_expr(pt.relpartbound, pt.oid, true)
+		FROM pg_class base_tb 
+		JOIN pg_inherits i on i.inhparent = base_tb.oid
+		JOIN pg_class pt on pt.oid = i.inhrelid
+		WHERE base_tb.oid = %L::regclass
+		ORDER BY pt.relname DESC
+		LIMIT 1;
+	', tableName) INTO partitionExpression;
+	
+	toDate := SUBSTRING(partitionExpression, 37, 10);
+
+	LOOP
+		fromDate := toDate;
+		counter := counter + 1;
+		toDate := fromDate + INTERVAL '7 days';
+
+		cmdStmt := format('CREATE TABLE IF NOT EXISTS %s_dm_em_uh_mats_%sw%s PARTITION OF %s
+			FOR VALUES FROM (%L) TO (%L);', tableName, year, LPAD(CAST(counter AS text), 2, '0'), tableName, fromDate, toDate);
+		RAISE NOTICE '%', cmdStmt;
+		IF executeFlag = 'Y' THEN
+			EXECUTE cmdStmt;
+			RAISE NOTICE '-- executed --';
+		END IF;
+
+		EXIT WHEN date_part('year', toDate) = year+1;
+	END LOOP;
+
+-------------------------------------------------------------------------------------------------------------------
+	tableName := schemaName || '.month_unit_data';
+	cmdStmt := format('CREATE TABLE IF NOT EXISTS %s_dm_em_um_%sm%s PARTITION OF %s
+		FOR VALUES FROM (%L, ''13'') TO (%L, ''2'');', tableName, year, '01', tableName, year-1, year);
+	RAISE NOTICE '%', cmdStmt;
+	IF executeFlag = 'Y' THEN
+		EXECUTE cmdStmt;
+		RAISE NOTICE '-- executed --';
+	END IF;
+	FOR i IN 2..12 LOOP
+		cmdStmt := format('CREATE TABLE IF NOT EXISTS %s_dm_em_um_%sm%s PARTITION OF %s
+			FOR VALUES FROM (%L, %L) TO (%L, %L);', tableName, year, LPAD(CAST(i AS text), 2, '0'), tableName, year, i, year, i+1);
+		RAISE NOTICE '%', cmdStmt;
+		IF executeFlag = 'Y' THEN
+			EXECUTE cmdStmt;
+			RAISE NOTICE '-- executed --';
+		END IF;
+	END LOOP;
+
+-------------------------------------------------------------------------------------------------------------------
+	tableName := schemaName || '.ozone_unit_data';
+	cmdStmt := format('CREATE TABLE IF NOT EXISTS %s_dm_em_uo_%s PARTITION OF %s
+				    FOR VALUES FROM (%L) TO (%L);', tableName, year, tableName, year, year+1);
+	RAISE NOTICE '%', cmdStmt;
+	IF executeFlag = 'Y' THEN
+		EXECUTE cmdStmt;
+		RAISE NOTICE '-- executed --';
+	END IF;
+
+-------------------------------------------------------------------------------------------------------------------
+	tableName := 'program_year_dim';
+	partitionName := tableName || '_prg_year_dim_p';
+	EXECUTE format('
+		SELECT MAX(CAST(REPLACE(table_name, %L, %L) AS integer))
+		FROM information_schema.tables
+		WHERE table_name like ''%s%%'';
+	', partitionName, '', partitionName) INTO partitionNumber;
+	cmdStmt := format('CREATE TABLE IF NOT EXISTS %s.%s%s PARTITION OF %s.%s
+				    FOR VALUES FROM (%L) TO (%L);', schemaName, partitionName, partitionNumber+1, schemaName, tableName, year, year+1);
+	RAISE NOTICE '%', cmdStmt;
+	IF executeFlag = 'Y' THEN
+		EXECUTE cmdStmt;
+		RAISE NOTICE '-- executed --';
+	END IF;
+
+-------------------------------------------------------------------------------------------------------------------
+	tableName := schemaName || '.quarter_unit_data';
+	cmdStmt := format('CREATE TABLE IF NOT EXISTS %s_dm_em_uq_%sq%s PARTITION OF %s
+		FOR VALUES FROM (%L, ''5'') TO (%L, ''2'');', tableName, year, '1', tableName, year-1, year);
+	RAISE NOTICE '%', cmdStmt;
+	IF executeFlag = 'Y' THEN
+		EXECUTE cmdStmt;
+		RAISE NOTICE '-- executed --';
+	END IF;
+	FOR i IN 2..4 LOOP
+		cmdStmt := format('CREATE TABLE IF NOT EXISTS %s_dm_em_uq_%sq%s PARTITION OF %s
+			FOR VALUES FROM (%L, %L) TO (%L, %L);', tableName, year, i, tableName, year, i, year, i+1);
+		RAISE NOTICE '%', cmdStmt;
+		IF executeFlag = 'Y' THEN
+			EXECUTE cmdStmt;
+			RAISE NOTICE '-- executed --';
+		END IF;
+	END LOOP;
+
+-------------------------------------------------------------------------------------------------------------------
+	tableName := 'unit_fact';
+	partitionName := tableName || '_unit_fact_tmp_p';
+	EXECUTE format('
+		SELECT MAX(CAST(REPLACE(table_name, %L, %L) AS integer))
+		FROM information_schema.tables
+		WHERE table_name like ''%s%%'';
+	', partitionName, '', partitionName) INTO partitionNumber;
+	cmdStmt := format('CREATE TABLE IF NOT EXISTS %s.%s%s PARTITION OF %s.%s
+				    FOR VALUES FROM (%L) TO (%L);', schemaName, partitionName, partitionNumber+1, schemaName, tableName, year, year+1);
+	RAISE NOTICE '%', cmdStmt;
+	IF executeFlag = 'Y' THEN
+		EXECUTE cmdStmt;
+		RAISE NOTICE '-- executed --';
+	END IF;
+
+-------------------------------------------------------------------------------------------------------------------
+	tableName := 'unit_type_year_dim';
+	partitionName := tableName || '_unit_type_yr_dim_p';
+	EXECUTE format('
+		SELECT MAX(CAST(REPLACE(table_name, %L, %L) AS integer))
+		FROM information_schema.tables
+		WHERE table_name like ''%s%%'';
+	', partitionName, '', partitionName) INTO partitionNumber;
+	cmdStmt := format('CREATE TABLE IF NOT EXISTS %s.%s%s PARTITION OF %s.%s
+				    FOR VALUES FROM (%L) TO (%L);', schemaName, partitionName, partitionNumber+1, schemaName, tableName, year, year+1);
+	RAISE NOTICE '%', cmdStmt;
+	IF executeFlag = 'Y' THEN
+		EXECUTE cmdStmt;
+		RAISE NOTICE '-- executed --';
+	END IF;
+
+END
+$BODY$;

--- a/deployments/campd/release-v1.8-fix/6665/camddmw/procedures/create_partitions.sql
+++ b/deployments/campd/release-v1.8-fix/6665/camddmw/procedures/create_partitions.sql
@@ -49,6 +49,10 @@ BEGIN
 	IF executeFlag = 'Y' THEN
 		EXECUTE cmdStmt;
 		RAISE NOTICE '-- executed --';
+	END IF;
+	
+	-- Separately check and insert op_year record
+	IF executeFlag = 'Y' THEN
 		EXECUTE format('SELECT COUNT(*) FROM camddmw.op_year WHERE op_year = %s', year) 
         INTO op_year_count;
 		IF op_year_count = 0 THEN

--- a/deployments/campd/release-v1.8-fix/6665/camddmw/procedures/create_partitions.sql
+++ b/deployments/campd/release-v1.8-fix/6665/camddmw/procedures/create_partitions.sql
@@ -51,16 +51,11 @@ BEGIN
 		RAISE NOTICE '-- executed --';
 	END IF;
 	
-	-- Separately check and insert op_year record
+	cmdStmt := format('INSERT INTO camddmw.op_year (op_year, archive_ind, hourly_data_ind) VALUES (%s, 0, 1)', year);
+	RAISE NOTICE '%', cmdStmt;
 	IF executeFlag = 'Y' THEN
-		EXECUTE format('SELECT COUNT(*) FROM camddmw.op_year WHERE op_year = %s', year) 
-        INTO op_year_count;
-		IF op_year_count = 0 THEN
-            EXECUTE format('
-                INSERT INTO camddmw.op_year (op_year, archive_ind, hourly_data_ind)
-                VALUES (%s, 0, 1)', year);
-            RAISE NOTICE '-- Added op_year record for year % --', year;
-		END IF;
+		EXECUTE cmdStmt;
+		RAISE NOTICE '-- executed --';
 	END IF;
 
 -------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Ticket
[CAMPD bug on quarterly emissions custom queries](https://github.com/US-EPA-CAMD/easey-ui/issues/6665)

## Changes

- Added the missing `camddmw.op_year` record with default vaules (2025)
- Updated to create_partitions.sql to insert a new `camddmw.op_year` record  when a new year partition is added to `annual_unit_data`.
