### PR TITLE
#6603 Corrected the column number and names returned by the function,…

### DIFF
--- a/camdecmpsaux/functions/pdem_job_get_next.sql
+++ b/camdecmpsaux/functions/pdem_job_get_next.sql
@@ -1,13 +1,14 @@
 create or replace function camdecmpsaux.PDEM_Job_Get_Next
 (
-    vJobLimit   smallint
+    vJobLimit   integer
 )
     returns table
             (
                 -- Need prefix to avoid ambiguous error with unaliased update columns below.
-                Next_Pdem_Report_Id bigint,
-                Next_Mon_Plan_Id varchar,
-                Next_Rpt_Period_Id numeric
+                Pdem_Report_Id bigint,
+                Mon_Plan_Id varchar,
+                Rpt_Period_Id numeric,
+                Submission_Id bigint
             )
 
 language plpgsql
@@ -18,37 +19,11 @@ declare
 begin
     
     return query
-        with    UPDATED as
-                (
-                    update  camdecmpsaux.PDEM_Report
-                       set  triggered_time = current_timestamp
-                     where  Pdem_Report_Id in
-                            (
-                                select  rpt.Pdem_Report_Id
-                                  from  camdecmpsaux.PDEM_Report rpt
-                                 where  rpt.triggered_time is null
-                                   and  not exists
-                                        (
-                                            select  1
-                                              from  camdecmpsaux.PDEM_Report exs
-                                             where  exs.triggered_time is not null
-                                               and  exs.completed_time is null
-                                               and  exs.note_time is null
-                                            having  ( count( 1 ) >= vJobLimit )
-                                        )
-                                 order
-                                    by  rpt.queued_Time
-                                 limit  1
-                                 for    update skip locked
-                            )
-                    returning   Pdem_Report_Id,
-                                Mon_Plan_Id,
-                                Rpt_Period_Id
-                )
-        select  upd.Pdem_Report_Id,
-                upd.Mon_Plan_Id,
-                upd.Rpt_Period_Id
-          from  UPDATED upd;
+        select  Next_Pdem_Report_Id,
+                Next_Mon_Plan_Id,
+                Next_Rpt_Period_Id,
+                Next_Submission_Id
+          from  camdecmpsaux.PDEM_Job_Get_Next_Core( vJobLimit );
 
 end;
 

--- a/camdecmpsaux/functions/pdem_job_get_next_core.sql
+++ b/camdecmpsaux/functions/pdem_job_get_next_core.sql
@@ -1,0 +1,58 @@
+create or replace function camdecmpsaux.PDEM_Job_Get_Next_Core
+(
+    vJobLimit   integer
+)
+    returns table
+            (
+                -- Need prefix to avoid ambiguous error with unaliased update columns below.
+                Next_Pdem_Report_Id bigint,
+                Next_Mon_Plan_Id varchar,
+                Next_Rpt_Period_Id numeric,
+                Next_Submission_Id bigint
+            )
+
+language plpgsql
+
+as $function$
+
+declare
+begin
+    
+    return query
+        with    UPDATED as
+                (
+                    update  camdecmpsaux.PDEM_Report
+                       set  triggered_time = current_timestamp
+                     where  Pdem_Report_Id in
+                            (
+                                select  rpt.Pdem_Report_Id
+                                  from  camdecmpsaux.PDEM_Report rpt
+                                 where  rpt.triggered_time is null
+                                   and  not exists
+                                        (
+                                            select  1
+                                              from  camdecmpsaux.PDEM_Report exs
+                                             where  exs.triggered_time is not null
+                                               and  exs.completed_time is null
+                                               and  exs.note_time is null
+                                            having  ( count( 1 ) >= vJobLimit )
+                                        )
+                                 order
+                                    by  rpt.queued_Time
+                                 limit  1
+                                 for    update skip locked
+                            )
+                    returning   Pdem_Report_Id as Next_Pdem_Report_Id,
+                                Mon_Plan_Id as Next_Mon_Plan_Id,
+                                Rpt_Period_Id as Next_Rpt_Period_Id,
+                                Submission_id as Next_Submission_Id
+                )
+        select  upd.Next_Pdem_Report_Id,
+                upd.Next_Mon_Plan_Id,
+                upd.Next_Rpt_Period_Id,
+                upd.Next_Submission_Id
+          from  UPDATED upd;
+
+end;
+
+$function$;

--- a/deployments/ecmps/release-v2.0-fix/Sprint18/6603/camdecmpsaux/procedures-functions/pdem_job_get_next.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint18/6603/camdecmpsaux/procedures-functions/pdem_job_get_next.sql
@@ -1,13 +1,14 @@
 create or replace function camdecmpsaux.PDEM_Job_Get_Next
 (
-    vJobLimit   smallint
+    vJobLimit   integer
 )
     returns table
             (
                 -- Need prefix to avoid ambiguous error with unaliased update columns below.
-                Next_Pdem_Report_Id bigint,
-                Next_Mon_Plan_Id varchar,
-                Next_Rpt_Period_Id numeric
+                Pdem_Report_Id bigint,
+                Mon_Plan_Id varchar,
+                Rpt_Period_Id numeric,
+                Submission_Id bigint
             )
 
 language plpgsql
@@ -18,37 +19,11 @@ declare
 begin
     
     return query
-        with    UPDATED as
-                (
-                    update  camdecmpsaux.PDEM_Report
-                       set  triggered_time = current_timestamp
-                     where  Pdem_Report_Id in
-                            (
-                                select  rpt.Pdem_Report_Id
-                                  from  camdecmpsaux.PDEM_Report rpt
-                                 where  rpt.triggered_time is null
-                                   and  not exists
-                                        (
-                                            select  1
-                                              from  camdecmpsaux.PDEM_Report exs
-                                             where  exs.triggered_time is not null
-                                               and  exs.completed_time is null
-                                               and  exs.note_time is null
-                                            having  ( count( 1 ) >= vJobLimit )
-                                        )
-                                 order
-                                    by  rpt.queued_Time
-                                 limit  1
-                                 for    update skip locked
-                            )
-                    returning   Pdem_Report_Id,
-                                Mon_Plan_Id,
-                                Rpt_Period_Id
-                )
-        select  upd.Pdem_Report_Id,
-                upd.Mon_Plan_Id,
-                upd.Rpt_Period_Id
-          from  UPDATED upd;
+        select  Next_Pdem_Report_Id,
+                Next_Mon_Plan_Id,
+                Next_Rpt_Period_Id,
+                Next_Submission_Id
+          from  camdecmpsaux.PDEM_Job_Get_Next_Core( vJobLimit );
 
 end;
 

--- a/deployments/ecmps/release-v2.0-fix/Sprint18/6603/camdecmpsaux/procedures-functions/pdem_job_get_next_core.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint18/6603/camdecmpsaux/procedures-functions/pdem_job_get_next_core.sql
@@ -1,0 +1,58 @@
+create or replace function camdecmpsaux.PDEM_Job_Get_Next_Core
+(
+    vJobLimit   integer
+)
+    returns table
+            (
+                -- Need prefix to avoid ambiguous error with unaliased update columns below.
+                Next_Pdem_Report_Id bigint,
+                Next_Mon_Plan_Id varchar,
+                Next_Rpt_Period_Id numeric,
+                Next_Submission_Id bigint
+            )
+
+language plpgsql
+
+as $function$
+
+declare
+begin
+    
+    return query
+        with    UPDATED as
+                (
+                    update  camdecmpsaux.PDEM_Report
+                       set  triggered_time = current_timestamp
+                     where  Pdem_Report_Id in
+                            (
+                                select  rpt.Pdem_Report_Id
+                                  from  camdecmpsaux.PDEM_Report rpt
+                                 where  rpt.triggered_time is null
+                                   and  not exists
+                                        (
+                                            select  1
+                                              from  camdecmpsaux.PDEM_Report exs
+                                             where  exs.triggered_time is not null
+                                               and  exs.completed_time is null
+                                               and  exs.note_time is null
+                                            having  ( count( 1 ) >= vJobLimit )
+                                        )
+                                 order
+                                    by  rpt.queued_Time
+                                 limit  1
+                                 for    update skip locked
+                            )
+                    returning   Pdem_Report_Id as Next_Pdem_Report_Id,
+                                Mon_Plan_Id as Next_Mon_Plan_Id,
+                                Rpt_Period_Id as Next_Rpt_Period_Id,
+                                Submission_id as Next_Submission_Id
+                )
+        select  upd.Next_Pdem_Report_Id,
+                upd.Next_Mon_Plan_Id,
+                upd.Next_Rpt_Period_Id,
+                upd.Next_Submission_Id
+          from  UPDATED upd;
+
+end;
+
+$function$;


### PR DESCRIPTION
1. Created PDEM_Job_Get_Next_Core to encapsulate the old version of PDEM_Job_Get_Next.
2. Updated PDEM_Job_Get_Next to call PDEM_Job_Get_Next_Core but remove the "Next_" prefix from the column names.
   - This was necessary because of the problem with using the actual column name in the core query.
3. Added Submission_Id as an output column.
4. Changed the input parameter type from small integer to integer.