### PR TITLE
submission in queue place

### DIFF
--- a/camdecmpswks/views/vw_em_eval_and_submit.sql
+++ b/camdecmpswks/views/vw_em_eval_and_submit.sql
@@ -27,15 +27,6 @@ WITH submission_ord AS (
     LEFT JOIN camdecmpswks.EMISSION_EVALUATION ems
         ON ems.mon_plan_id = ss.mon_plan_id
         AND ems.rpt_period_id = sq.rpt_period_id
-    WHERE (
-        sq.process_cd = 'MP' AND pln.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'QA' AND sq.qa_cert_event_id IS NOT NULL AND qce.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'QA' AND sq.test_extension_exemption_id IS NOT NULL AND tee.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'EM' AND ems.submission_availability_cd = 'PENDING'
-    )
 ),
 evaluation_ord AS (
   SELECT 

--- a/camdecmpswks/views/vw_em_eval_and_submit.sql
+++ b/camdecmpswks/views/vw_em_eval_and_submit.sql
@@ -2,7 +2,42 @@
 DROP VIEW IF EXISTS camdecmpswks.vw_em_eval_and_submit;
 
 CREATE OR REPLACE VIEW camdecmpswks.vw_em_eval_and_submit AS
-WITH ord AS (
+WITH submission_ord AS (
+    SELECT  
+        ss.submission_set_id, 
+        sq.submission_id,
+        ss.mon_plan_id,
+        sq.test_sum_id,
+        sq.qa_cert_event_id,
+        sq.test_extension_exemption_id,
+        sq.rpt_period_id,
+        ROW_NUMBER() OVER (ORDER BY ss.queued_time) AS submission_queue_position 
+    FROM camdecmpsaux.submission_set ss 
+    JOIN camdecmpsaux.submission_queue sq
+        ON sq.submission_set_id = ss.submission_set_id 
+        AND sq.status_cd = 'QUEUED'
+    LEFT JOIN camdecmpswks.MONITOR_PLAN pln
+        ON pln.mon_plan_id = ss.mon_plan_id 
+    LEFT JOIN camdecmpswks.TEST_SUMMARY tst
+        ON tst.test_sum_id = sq.test_sum_id
+    LEFT JOIN camdecmpswks.QA_CERT_EVENT qce
+        ON qce.qa_cert_event_id = sq.qa_cert_event_id
+    LEFT JOIN camdecmpswks.TEST_EXTENSION_EXEMPTION tee
+        ON tee.test_extension_exemption_id = sq.test_extension_exemption_id
+    LEFT JOIN camdecmpswks.EMISSION_EVALUATION ems
+        ON ems.mon_plan_id = ss.mon_plan_id
+        AND ems.rpt_period_id = sq.rpt_period_id
+    WHERE (
+        sq.process_cd = 'MP' AND pln.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'QA' AND sq.qa_cert_event_id IS NOT NULL AND qce.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'QA' AND sq.test_extension_exemption_id IS NOT NULL AND tee.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'EM' AND ems.submission_availability_cd = 'PENDING'
+    )
+),
+evaluation_ord AS (
   SELECT 
     evs.evaluation_set_id, 
     evq.evaluation_id, 
@@ -14,7 +49,7 @@ WITH ord AS (
     ROW_NUMBER() OVER (
       ORDER BY 
         evs.queued_time
-    ) AS queue_position 
+    ) AS evaluation_queue_position 
   FROM 
     camdecmpsaux.EVALUATION_SET evs 
     JOIN camdecmpsaux.EVALUATION_QUEUE evq ON evq.evaluation_set_id = evs.evaluation_set_id 
@@ -67,17 +102,30 @@ SELECT
     CASE WHEN esc.eval_status_cd = 'INQ' THEN COALESCE(
     'In Queue (#' || (
       SELECT 
-        MIN(queue_position) 
+        MIN(evaluation_queue_position) 
       FROM 
-        ord 
+        evaluation_ord 
       WHERE 
-        ord.rpt_period_id = sel.rpt_period_id
-        and ord.mon_plan_id  = sel.mon_plan_id 
+        evaluation_ord.rpt_period_id = sel.rpt_period_id
+        and evaluation_ord.mon_plan_id  = sel.mon_plan_id 
     ):: TEXT || ' in queue)', 
     esc.eval_status_cd_description
   ) ELSE esc.eval_status_cd_description END AS eval_status_cd_description, 
     sac.submission_availability_cd,
-    sac.sub_avail_cd_description AS submission_availability_cd_description,
+    CASE 
+        WHEN sac.submission_availability_cd = 'PENDING' THEN 
+            COALESCE(
+                'Submitted, Host Update Pending (#' || (
+                    SELECT MIN(submission_queue_position) 
+                    FROM submission_ord 
+                    WHERE 
+                        submission_ord.rpt_period_id = sel.rpt_period_id
+                        and submission_ord.mon_plan_id  = sel.mon_plan_id 
+                )::TEXT || ' in queue)', 
+                sac.sub_avail_cd_description
+            )
+        ELSE sac.sub_avail_cd_description 
+    END AS submission_availability_cd_description,
     sel.userid :: varchar(160),
         sel.last_updated AS update_date,
     (

--- a/camdecmpswks/views/vw_qa_cert_event_eval_and_submit.sql
+++ b/camdecmpswks/views/vw_qa_cert_event_eval_and_submit.sql
@@ -4,7 +4,42 @@ DROP VIEW IF EXISTS camdecmpswks.vw_qa_cert_event_eval_and_submit;
 
 CREATE OR REPLACE VIEW camdecmpswks.vw_qa_cert_event_eval_and_submit
  AS
- WITH ord AS (
+ WITH submission_ord AS (
+    SELECT  
+        ss.submission_set_id, 
+        sq.submission_id,
+        ss.mon_plan_id,
+        sq.test_sum_id,
+        sq.qa_cert_event_id,
+        sq.test_extension_exemption_id,
+        sq.rpt_period_id,
+        ROW_NUMBER() OVER (ORDER BY ss.queued_time) AS submission_queue_position 
+    FROM camdecmpsaux.submission_set ss 
+    JOIN camdecmpsaux.submission_queue sq
+        ON sq.submission_set_id = ss.submission_set_id 
+        AND sq.status_cd = 'QUEUED'
+    LEFT JOIN camdecmpswks.MONITOR_PLAN pln
+        ON pln.mon_plan_id = ss.mon_plan_id 
+    LEFT JOIN camdecmpswks.TEST_SUMMARY tst
+        ON tst.test_sum_id = sq.test_sum_id
+    LEFT JOIN camdecmpswks.QA_CERT_EVENT qce
+        ON qce.qa_cert_event_id = sq.qa_cert_event_id
+    LEFT JOIN camdecmpswks.TEST_EXTENSION_EXEMPTION tee
+        ON tee.test_extension_exemption_id = sq.test_extension_exemption_id
+    LEFT JOIN camdecmpswks.EMISSION_EVALUATION ems
+        ON ems.mon_plan_id = ss.mon_plan_id
+        AND ems.rpt_period_id = sq.rpt_period_id
+    WHERE (
+        sq.process_cd = 'MP' AND pln.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'QA' AND sq.qa_cert_event_id IS NOT NULL AND qce.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'QA' AND sq.test_extension_exemption_id IS NOT NULL AND tee.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'EM' AND ems.submission_availability_cd = 'PENDING'
+    )
+),
+ evaluation_ord AS (
   SELECT 
     evs.evaluation_set_id, 
     evq.evaluation_id, 
@@ -16,7 +51,7 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_qa_cert_event_eval_and_submit
     ROW_NUMBER() OVER (
       ORDER BY 
         evs.queued_time
-    ) AS queue_position 
+    ) AS evaluation_queue_position 
   FROM 
     camdecmpsaux.EVALUATION_SET evs 
     JOIN camdecmpsaux.EVALUATION_QUEUE evq ON evq.evaluation_set_id = evs.evaluation_set_id 
@@ -71,16 +106,27 @@ SELECT p.oris_code,
     CASE WHEN qce.eval_status_cd = 'INQ' THEN COALESCE(
     'In Queue (#' || (
       SELECT 
-        MIN(queue_position) 
+        MIN(evaluation_queue_position) 
       FROM 
-        ord 
+        evaluation_ord 
       WHERE 
-        ord.qa_cert_event_id = qce.qa_cert_event_id
+        evaluation_ord.qa_cert_event_id = qce.qa_cert_event_id
     ):: TEXT || ' in queue)', 
     esc.eval_status_cd_description
   ) ELSE esc.eval_status_cd_description END AS eval_status_cd_description, 
     qce.submission_availability_cd,
-    sac.sub_avail_cd_description as submission_availability_cd_description
+    CASE 
+        WHEN qce.submission_availability_cd = 'PENDING' THEN 
+            COALESCE(
+                'Submitted, Host Update Pending (#' || (
+                    SELECT MIN(submission_queue_position) 
+                    FROM submission_ord 
+                    WHERE submission_ord.qa_cert_event_id = qce.qa_cert_event_id
+                )::TEXT || ' in queue)', 
+                sac.sub_avail_cd_description
+            )
+        ELSE sac.sub_avail_cd_description 
+    END AS submission_availability_cd_description
    FROM camd.plant p
      JOIN camdecmpswks.monitor_plan mp USING (fac_id)
      JOIN camdecmpswks.monitor_plan_location mpl USING (mon_plan_id)

--- a/camdecmpswks/views/vw_qa_cert_event_eval_and_submit.sql
+++ b/camdecmpswks/views/vw_qa_cert_event_eval_and_submit.sql
@@ -29,15 +29,6 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_qa_cert_event_eval_and_submit
     LEFT JOIN camdecmpswks.EMISSION_EVALUATION ems
         ON ems.mon_plan_id = ss.mon_plan_id
         AND ems.rpt_period_id = sq.rpt_period_id
-    WHERE (
-        sq.process_cd = 'MP' AND pln.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'QA' AND sq.qa_cert_event_id IS NOT NULL AND qce.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'QA' AND sq.test_extension_exemption_id IS NOT NULL AND tee.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'EM' AND ems.submission_availability_cd = 'PENDING'
-    )
 ),
  evaluation_ord AS (
   SELECT 

--- a/camdecmpswks/views/vw_test_extension_exemption_eval_and_submit.sql
+++ b/camdecmpswks/views/vw_test_extension_exemption_eval_and_submit.sql
@@ -4,7 +4,42 @@ DROP VIEW IF EXISTS camdecmpswks.vw_test_extension_exemption_eval_and_submit;
 
 CREATE OR REPLACE VIEW camdecmpswks.vw_test_extension_exemption_eval_and_submit
  AS
- WITH ord AS (
+ WITH submission_ord AS (
+    SELECT  
+        ss.submission_set_id, 
+        sq.submission_id,
+        ss.mon_plan_id,
+        sq.test_sum_id,
+        sq.qa_cert_event_id,
+        sq.test_extension_exemption_id,
+        sq.rpt_period_id,
+        ROW_NUMBER() OVER (ORDER BY ss.queued_time) AS submission_queue_position 
+    FROM camdecmpsaux.submission_set ss 
+    JOIN camdecmpsaux.submission_queue sq
+        ON sq.submission_set_id = ss.submission_set_id 
+        AND sq.status_cd = 'QUEUED'
+    LEFT JOIN camdecmpswks.MONITOR_PLAN pln
+        ON pln.mon_plan_id = ss.mon_plan_id 
+    LEFT JOIN camdecmpswks.TEST_SUMMARY tst
+        ON tst.test_sum_id = sq.test_sum_id
+    LEFT JOIN camdecmpswks.QA_CERT_EVENT qce
+        ON qce.qa_cert_event_id = sq.qa_cert_event_id
+    LEFT JOIN camdecmpswks.TEST_EXTENSION_EXEMPTION tee
+        ON tee.test_extension_exemption_id = sq.test_extension_exemption_id
+    LEFT JOIN camdecmpswks.EMISSION_EVALUATION ems
+        ON ems.mon_plan_id = ss.mon_plan_id
+        AND ems.rpt_period_id = sq.rpt_period_id
+    WHERE (
+        sq.process_cd = 'MP' AND pln.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'QA' AND sq.qa_cert_event_id IS NOT NULL AND qce.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'QA' AND sq.test_extension_exemption_id IS NOT NULL AND tee.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'EM' AND ems.submission_availability_cd = 'PENDING'
+    )
+),
+ evaluation_ord  AS (
     SELECT  
         evs.evaluation_set_id, 
         evq.evaluation_id,
@@ -13,7 +48,7 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_test_extension_exemption_eval_and_submit
         evq.qa_cert_event_id,
         evq.test_extension_exemption_id,
         evq.rpt_period_id,
-        ROW_NUMBER() OVER (ORDER BY evs.queued_time) AS queue_position 
+        ROW_NUMBER() OVER (ORDER BY evs.queued_time) AS evaluation_queue_position 
     FROM camdecmpsaux.EVALUATION_SET evs 
     JOIN camdecmpsaux.EVALUATION_QUEUE evq
         ON evq.evaluation_set_id = evs.evaluation_set_id 
@@ -57,16 +92,27 @@ SELECT p.oris_code,
         WHEN tee.eval_status_cd = 'INQ' THEN 
             COALESCE(
                 'In Queue (#' || (
-                    SELECT MIN(queue_position)
-                    FROM ord
-                    WHERE ord.test_extension_exemption_id = tee.test_extension_exemption_id
+                    SELECT MIN(evaluation_queue_position)
+                    FROM evaluation_ord
+                    WHERE evaluation_ord.test_extension_exemption_id = tee.test_extension_exemption_id
                 )::TEXT || ' in queue)',
                 esc.eval_status_cd_description
             )
         ELSE esc.eval_status_cd_description 
     END AS eval_status_cd_description,
     tee.submission_availability_cd,
-    sac.sub_avail_cd_description as submission_availability_cd_description,
+    CASE 
+        WHEN tee.submission_availability_cd = 'PENDING' THEN 
+            COALESCE(
+                'Submitted, Host Update Pending (#' || (
+                    SELECT MIN(submission_queue_position) 
+                    FROM submission_ord 
+                    WHERE submission_ord.test_extension_exemption_id = tee.test_extension_exemption_id
+                )::TEXT || ' in queue)', 
+                sac.sub_avail_cd_description
+            )
+        ELSE sac.sub_avail_cd_description 
+    END AS submission_availability_cd_description,
 	tee.fuel_cd,
     tee.hours_used,
     tee.span_scale_cd,

--- a/camdecmpswks/views/vw_test_extension_exemption_eval_and_submit.sql
+++ b/camdecmpswks/views/vw_test_extension_exemption_eval_and_submit.sql
@@ -29,15 +29,6 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_test_extension_exemption_eval_and_submit
     LEFT JOIN camdecmpswks.EMISSION_EVALUATION ems
         ON ems.mon_plan_id = ss.mon_plan_id
         AND ems.rpt_period_id = sq.rpt_period_id
-    WHERE (
-        sq.process_cd = 'MP' AND pln.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'QA' AND sq.qa_cert_event_id IS NOT NULL AND qce.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'QA' AND sq.test_extension_exemption_id IS NOT NULL AND tee.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'EM' AND ems.submission_availability_cd = 'PENDING'
-    )
 ),
  evaluation_ord  AS (
     SELECT  

--- a/camdecmpswks/views/vw_test_summary_eval_and_submit.sql
+++ b/camdecmpswks/views/vw_test_summary_eval_and_submit.sql
@@ -4,7 +4,33 @@ DROP VIEW IF EXISTS camdecmpswks.vw_test_summary_eval_and_submit;
 
 CREATE OR REPLACE VIEW camdecmpswks.vw_test_summary_eval_and_submit
  AS
- WITH ord AS (
+  WITH submission_ord AS (
+    SELECT  
+        ss.submission_set_id, 
+        sq.submission_id,
+        ss.mon_plan_id,
+        sq.test_sum_id,
+        sq.qa_cert_event_id,
+        sq.test_extension_exemption_id,
+        sq.rpt_period_id,
+        ROW_NUMBER() OVER (ORDER BY ss.queued_time) AS submission_queue_position 
+    FROM camdecmpsaux.submission_set ss 
+    JOIN camdecmpsaux.submission_queue sq
+        ON sq.submission_set_id = ss.submission_set_id 
+        AND sq.status_cd = 'QUEUED'
+    LEFT JOIN camdecmpswks.MONITOR_PLAN pln
+        ON pln.mon_plan_id = ss.mon_plan_id 
+    LEFT JOIN camdecmpswks.TEST_SUMMARY tst
+        ON tst.test_sum_id = sq.test_sum_id
+    LEFT JOIN camdecmpswks.QA_CERT_EVENT qce
+        ON qce.qa_cert_event_id = sq.qa_cert_event_id
+    LEFT JOIN camdecmpswks.TEST_EXTENSION_EXEMPTION tee
+        ON tee.test_extension_exemption_id = sq.test_extension_exemption_id
+    LEFT JOIN camdecmpswks.EMISSION_EVALUATION ems
+        ON ems.mon_plan_id = ss.mon_plan_id
+        AND ems.rpt_period_id = sq.rpt_period_id
+),
+ evaluation_ord AS (
     SELECT  
         evs.evaluation_set_id, 
         evq.evaluation_id,
@@ -72,15 +98,26 @@ SELECT p.oris_code,
             COALESCE(
                 'In Queue (#' || (
                     SELECT MIN(queue_position)
-                    FROM ord
-                    WHERE ord.test_sum_id = ts.test_sum_id 
+                    FROM evaluation_ord
+                    WHERE evaluation_ord.test_sum_id = ts.test_sum_id 
                 )::TEXT || ' in queue)',
                 esc.eval_status_cd_description
             )
         ELSE esc.eval_status_cd_description 
     END AS eval_status_cd_description,
     qsd.submission_availability_cd,
-    sac.sub_avail_cd_description as submission_availability_cd_description,
+    CASE 
+        WHEN sac.submission_availability_cd = 'PENDING' THEN 
+            COALESCE(
+                'Submitted, Host Update Pending (#' || (
+                    SELECT MIN(submission_queue_position) 
+                    FROM submission_ord 
+                    WHERE submission_ord.test_sum_id = ts.test_sum_id
+                )::TEXT || ' in queue)', 
+                sac.sub_avail_cd_description
+            )
+        ELSE sac.sub_avail_cd_description 
+    END AS submission_availability_cd_description,
     rp.period_abbreviation
    FROM camd.plant p
      JOIN camdecmpswks.monitor_plan mp USING (fac_id)

--- a/deployments/ecmps/release-v2.0-fix/Sprint19/6619/camdecmpswks/views/vw_em_eval_and_submit.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint19/6619/camdecmpswks/views/vw_em_eval_and_submit.sql
@@ -27,15 +27,6 @@ WITH submission_ord AS (
     LEFT JOIN camdecmpswks.EMISSION_EVALUATION ems
         ON ems.mon_plan_id = ss.mon_plan_id
         AND ems.rpt_period_id = sq.rpt_period_id
-    WHERE (
-        sq.process_cd = 'MP' AND pln.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'QA' AND sq.qa_cert_event_id IS NOT NULL AND qce.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'QA' AND sq.test_extension_exemption_id IS NOT NULL AND tee.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'EM' AND ems.submission_availability_cd = 'PENDING'
-    )
 ),
 evaluation_ord AS (
   SELECT 

--- a/deployments/ecmps/release-v2.0-fix/Sprint19/6619/camdecmpswks/views/vw_em_eval_and_submit.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint19/6619/camdecmpswks/views/vw_em_eval_and_submit.sql
@@ -2,7 +2,42 @@
 DROP VIEW IF EXISTS camdecmpswks.vw_em_eval_and_submit;
 
 CREATE OR REPLACE VIEW camdecmpswks.vw_em_eval_and_submit AS
-WITH ord AS (
+WITH submission_ord AS (
+    SELECT  
+        ss.submission_set_id, 
+        sq.submission_id,
+        ss.mon_plan_id,
+        sq.test_sum_id,
+        sq.qa_cert_event_id,
+        sq.test_extension_exemption_id,
+        sq.rpt_period_id,
+        ROW_NUMBER() OVER (ORDER BY ss.queued_time) AS submission_queue_position 
+    FROM camdecmpsaux.submission_set ss 
+    JOIN camdecmpsaux.submission_queue sq
+        ON sq.submission_set_id = ss.submission_set_id 
+        AND sq.status_cd = 'QUEUED'
+    LEFT JOIN camdecmpswks.MONITOR_PLAN pln
+        ON pln.mon_plan_id = ss.mon_plan_id 
+    LEFT JOIN camdecmpswks.TEST_SUMMARY tst
+        ON tst.test_sum_id = sq.test_sum_id
+    LEFT JOIN camdecmpswks.QA_CERT_EVENT qce
+        ON qce.qa_cert_event_id = sq.qa_cert_event_id
+    LEFT JOIN camdecmpswks.TEST_EXTENSION_EXEMPTION tee
+        ON tee.test_extension_exemption_id = sq.test_extension_exemption_id
+    LEFT JOIN camdecmpswks.EMISSION_EVALUATION ems
+        ON ems.mon_plan_id = ss.mon_plan_id
+        AND ems.rpt_period_id = sq.rpt_period_id
+    WHERE (
+        sq.process_cd = 'MP' AND pln.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'QA' AND sq.qa_cert_event_id IS NOT NULL AND qce.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'QA' AND sq.test_extension_exemption_id IS NOT NULL AND tee.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'EM' AND ems.submission_availability_cd = 'PENDING'
+    )
+),
+evaluation_ord AS (
   SELECT 
     evs.evaluation_set_id, 
     evq.evaluation_id, 
@@ -14,7 +49,7 @@ WITH ord AS (
     ROW_NUMBER() OVER (
       ORDER BY 
         evs.queued_time
-    ) AS queue_position 
+    ) AS evaluation_queue_position 
   FROM 
     camdecmpsaux.EVALUATION_SET evs 
     JOIN camdecmpsaux.EVALUATION_QUEUE evq ON evq.evaluation_set_id = evs.evaluation_set_id 
@@ -67,17 +102,30 @@ SELECT
     CASE WHEN esc.eval_status_cd = 'INQ' THEN COALESCE(
     'In Queue (#' || (
       SELECT 
-        MIN(queue_position) 
+        MIN(evaluation_queue_position) 
       FROM 
-        ord 
+        evaluation_ord 
       WHERE 
-        ord.rpt_period_id = sel.rpt_period_id
-        and ord.mon_plan_id  = sel.mon_plan_id 
+        evaluation_ord.rpt_period_id = sel.rpt_period_id
+        and evaluation_ord.mon_plan_id  = sel.mon_plan_id 
     ):: TEXT || ' in queue)', 
     esc.eval_status_cd_description
   ) ELSE esc.eval_status_cd_description END AS eval_status_cd_description, 
     sac.submission_availability_cd,
-    sac.sub_avail_cd_description AS submission_availability_cd_description,
+    CASE 
+        WHEN sac.submission_availability_cd = 'PENDING' THEN 
+            COALESCE(
+                'Submitted, Host Update Pending (#' || (
+                    SELECT MIN(submission_queue_position) 
+                    FROM submission_ord 
+                    WHERE 
+                        submission_ord.rpt_period_id = sel.rpt_period_id
+                        and submission_ord.mon_plan_id  = sel.mon_plan_id 
+                )::TEXT || ' in queue)', 
+                sac.sub_avail_cd_description
+            )
+        ELSE sac.sub_avail_cd_description 
+    END AS submission_availability_cd_description,
     sel.userid :: varchar(160),
         sel.last_updated AS update_date,
     (
@@ -145,14 +193,14 @@ FROM
             (
                 SELECT
                     ems.Mon_Plan_Id,
-                    max(ems.last_updated) AS last_updated
+                    min(ems.rpt_period_id) AS earlist_quarter
                 FROM
                     camdecmpswks.EMISSION_EVALUATION ems
                 GROUP BY
                     ems.Mon_Plan_Id
             ) sel
                 JOIN camdecmpswks.EMISSION_EVALUATION ems ON ems.Mon_Plan_Id = sel.Mon_Plan_Id
-                AND ems.last_updated = sel.last_updated
+                AND ems.rpt_period_id = sel.earlist_quarter
     ) sel
         JOIN camdecmpsmd.reporting_period prd ON prd.rpt_period_id = sel.rpt_period_id
         JOIN camdecmpswks.monitor_plan pln ON pln.mon_plan_id = sel.mon_plan_id

--- a/deployments/ecmps/release-v2.0-fix/Sprint19/6619/camdecmpswks/views/vw_qa_cert_event_eval_and_submit.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint19/6619/camdecmpswks/views/vw_qa_cert_event_eval_and_submit.sql
@@ -4,7 +4,42 @@ DROP VIEW IF EXISTS camdecmpswks.vw_qa_cert_event_eval_and_submit;
 
 CREATE OR REPLACE VIEW camdecmpswks.vw_qa_cert_event_eval_and_submit
  AS
- WITH ord AS (
+ WITH submission_ord AS (
+    SELECT  
+        ss.submission_set_id, 
+        sq.submission_id,
+        ss.mon_plan_id,
+        sq.test_sum_id,
+        sq.qa_cert_event_id,
+        sq.test_extension_exemption_id,
+        sq.rpt_period_id,
+        ROW_NUMBER() OVER (ORDER BY ss.queued_time) AS submission_queue_position 
+    FROM camdecmpsaux.submission_set ss 
+    JOIN camdecmpsaux.submission_queue sq
+        ON sq.submission_set_id = ss.submission_set_id 
+        AND sq.status_cd = 'QUEUED'
+    LEFT JOIN camdecmpswks.MONITOR_PLAN pln
+        ON pln.mon_plan_id = ss.mon_plan_id 
+    LEFT JOIN camdecmpswks.TEST_SUMMARY tst
+        ON tst.test_sum_id = sq.test_sum_id
+    LEFT JOIN camdecmpswks.QA_CERT_EVENT qce
+        ON qce.qa_cert_event_id = sq.qa_cert_event_id
+    LEFT JOIN camdecmpswks.TEST_EXTENSION_EXEMPTION tee
+        ON tee.test_extension_exemption_id = sq.test_extension_exemption_id
+    LEFT JOIN camdecmpswks.EMISSION_EVALUATION ems
+        ON ems.mon_plan_id = ss.mon_plan_id
+        AND ems.rpt_period_id = sq.rpt_period_id
+    WHERE (
+        sq.process_cd = 'MP' AND pln.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'QA' AND sq.qa_cert_event_id IS NOT NULL AND qce.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'QA' AND sq.test_extension_exemption_id IS NOT NULL AND tee.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'EM' AND ems.submission_availability_cd = 'PENDING'
+    )
+),
+ evaluation_ord AS (
   SELECT 
     evs.evaluation_set_id, 
     evq.evaluation_id, 
@@ -16,7 +51,7 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_qa_cert_event_eval_and_submit
     ROW_NUMBER() OVER (
       ORDER BY 
         evs.queued_time
-    ) AS queue_position 
+    ) AS evaluation_queue_position 
   FROM 
     camdecmpsaux.EVALUATION_SET evs 
     JOIN camdecmpsaux.EVALUATION_QUEUE evq ON evq.evaluation_set_id = evs.evaluation_set_id 
@@ -71,16 +106,27 @@ SELECT p.oris_code,
     CASE WHEN qce.eval_status_cd = 'INQ' THEN COALESCE(
     'In Queue (#' || (
       SELECT 
-        MIN(queue_position) 
+        MIN(evaluation_queue_position) 
       FROM 
-        ord 
+        evaluation_ord 
       WHERE 
-        ord.qa_cert_event_id = qce.qa_cert_event_id
+        evaluation_ord.qa_cert_event_id = qce.qa_cert_event_id
     ):: TEXT || ' in queue)', 
     esc.eval_status_cd_description
   ) ELSE esc.eval_status_cd_description END AS eval_status_cd_description, 
     qce.submission_availability_cd,
-    sac.sub_avail_cd_description as submission_availability_cd_description
+    CASE 
+        WHEN qce.submission_availability_cd = 'PENDING' THEN 
+            COALESCE(
+                'Submitted, Host Update Pending (#' || (
+                    SELECT MIN(submission_queue_position) 
+                    FROM submission_ord 
+                    WHERE submission_ord.qa_cert_event_id = qce.qa_cert_event_id
+                )::TEXT || ' in queue)', 
+                sac.sub_avail_cd_description
+            )
+        ELSE sac.sub_avail_cd_description 
+    END AS submission_availability_cd_description
    FROM camd.plant p
      JOIN camdecmpswks.monitor_plan mp USING (fac_id)
      JOIN camdecmpswks.monitor_plan_location mpl USING (mon_plan_id)

--- a/deployments/ecmps/release-v2.0-fix/Sprint19/6619/camdecmpswks/views/vw_qa_cert_event_eval_and_submit.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint19/6619/camdecmpswks/views/vw_qa_cert_event_eval_and_submit.sql
@@ -29,15 +29,6 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_qa_cert_event_eval_and_submit
     LEFT JOIN camdecmpswks.EMISSION_EVALUATION ems
         ON ems.mon_plan_id = ss.mon_plan_id
         AND ems.rpt_period_id = sq.rpt_period_id
-    WHERE (
-        sq.process_cd = 'MP' AND pln.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'QA' AND sq.qa_cert_event_id IS NOT NULL AND qce.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'QA' AND sq.test_extension_exemption_id IS NOT NULL AND tee.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'EM' AND ems.submission_availability_cd = 'PENDING'
-    )
 ),
  evaluation_ord AS (
   SELECT 

--- a/deployments/ecmps/release-v2.0-fix/Sprint19/6619/camdecmpswks/views/vw_test_extension_exemption_eval_and_submit.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint19/6619/camdecmpswks/views/vw_test_extension_exemption_eval_and_submit.sql
@@ -4,7 +4,42 @@ DROP VIEW IF EXISTS camdecmpswks.vw_test_extension_exemption_eval_and_submit;
 
 CREATE OR REPLACE VIEW camdecmpswks.vw_test_extension_exemption_eval_and_submit
  AS
- WITH ord AS (
+ WITH submission_ord AS (
+    SELECT  
+        ss.submission_set_id, 
+        sq.submission_id,
+        ss.mon_plan_id,
+        sq.test_sum_id,
+        sq.qa_cert_event_id,
+        sq.test_extension_exemption_id,
+        sq.rpt_period_id,
+        ROW_NUMBER() OVER (ORDER BY ss.queued_time) AS submission_queue_position 
+    FROM camdecmpsaux.submission_set ss 
+    JOIN camdecmpsaux.submission_queue sq
+        ON sq.submission_set_id = ss.submission_set_id 
+        AND sq.status_cd = 'QUEUED'
+    LEFT JOIN camdecmpswks.MONITOR_PLAN pln
+        ON pln.mon_plan_id = ss.mon_plan_id 
+    LEFT JOIN camdecmpswks.TEST_SUMMARY tst
+        ON tst.test_sum_id = sq.test_sum_id
+    LEFT JOIN camdecmpswks.QA_CERT_EVENT qce
+        ON qce.qa_cert_event_id = sq.qa_cert_event_id
+    LEFT JOIN camdecmpswks.TEST_EXTENSION_EXEMPTION tee
+        ON tee.test_extension_exemption_id = sq.test_extension_exemption_id
+    LEFT JOIN camdecmpswks.EMISSION_EVALUATION ems
+        ON ems.mon_plan_id = ss.mon_plan_id
+        AND ems.rpt_period_id = sq.rpt_period_id
+    WHERE (
+        sq.process_cd = 'MP' AND pln.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'QA' AND sq.qa_cert_event_id IS NOT NULL AND qce.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'QA' AND sq.test_extension_exemption_id IS NOT NULL AND tee.submission_availability_cd = 'PENDING'
+        OR
+        sq.process_cd = 'EM' AND ems.submission_availability_cd = 'PENDING'
+    )
+),
+ evaluation_ord  AS (
     SELECT  
         evs.evaluation_set_id, 
         evq.evaluation_id,
@@ -13,7 +48,7 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_test_extension_exemption_eval_and_submit
         evq.qa_cert_event_id,
         evq.test_extension_exemption_id,
         evq.rpt_period_id,
-        ROW_NUMBER() OVER (ORDER BY evs.queued_time) AS queue_position 
+        ROW_NUMBER() OVER (ORDER BY evs.queued_time) AS evaluation_queue_position 
     FROM camdecmpsaux.EVALUATION_SET evs 
     JOIN camdecmpsaux.EVALUATION_QUEUE evq
         ON evq.evaluation_set_id = evs.evaluation_set_id 
@@ -57,16 +92,27 @@ SELECT p.oris_code,
         WHEN tee.eval_status_cd = 'INQ' THEN 
             COALESCE(
                 'In Queue (#' || (
-                    SELECT MIN(queue_position)
-                    FROM ord
-                    WHERE ord.test_extension_exemption_id = tee.test_extension_exemption_id
+                    SELECT MIN(evaluation_queue_position)
+                    FROM evaluation_ord
+                    WHERE evaluation_ord.test_extension_exemption_id = tee.test_extension_exemption_id
                 )::TEXT || ' in queue)',
                 esc.eval_status_cd_description
             )
         ELSE esc.eval_status_cd_description 
     END AS eval_status_cd_description,
     tee.submission_availability_cd,
-    sac.sub_avail_cd_description as submission_availability_cd_description,
+    CASE 
+        WHEN tee.submission_availability_cd = 'PENDING' THEN 
+            COALESCE(
+                'Submitted, Host Update Pending (#' || (
+                    SELECT MIN(submission_queue_position) 
+                    FROM submission_ord 
+                    WHERE submission_ord.test_extension_exemption_id = tee.test_extension_exemption_id
+                )::TEXT || ' in queue)', 
+                sac.sub_avail_cd_description
+            )
+        ELSE sac.sub_avail_cd_description 
+    END AS submission_availability_cd_description,
 	tee.fuel_cd,
     tee.hours_used,
     tee.span_scale_cd,

--- a/deployments/ecmps/release-v2.0-fix/Sprint19/6619/camdecmpswks/views/vw_test_extension_exemption_eval_and_submit.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint19/6619/camdecmpswks/views/vw_test_extension_exemption_eval_and_submit.sql
@@ -29,15 +29,6 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_test_extension_exemption_eval_and_submit
     LEFT JOIN camdecmpswks.EMISSION_EVALUATION ems
         ON ems.mon_plan_id = ss.mon_plan_id
         AND ems.rpt_period_id = sq.rpt_period_id
-    WHERE (
-        sq.process_cd = 'MP' AND pln.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'QA' AND sq.qa_cert_event_id IS NOT NULL AND qce.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'QA' AND sq.test_extension_exemption_id IS NOT NULL AND tee.submission_availability_cd = 'PENDING'
-        OR
-        sq.process_cd = 'EM' AND ems.submission_availability_cd = 'PENDING'
-    )
 ),
  evaluation_ord  AS (
     SELECT  

--- a/deployments/ecmps/release-v2.0-fix/Sprint19/6619/camdecmpswks/views/vw_test_summary_eval_and_submit.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint19/6619/camdecmpswks/views/vw_test_summary_eval_and_submit.sql
@@ -4,7 +4,33 @@ DROP VIEW IF EXISTS camdecmpswks.vw_test_summary_eval_and_submit;
 
 CREATE OR REPLACE VIEW camdecmpswks.vw_test_summary_eval_and_submit
  AS
- WITH ord AS (
+  WITH submission_ord AS (
+    SELECT  
+        ss.submission_set_id, 
+        sq.submission_id,
+        ss.mon_plan_id,
+        sq.test_sum_id,
+        sq.qa_cert_event_id,
+        sq.test_extension_exemption_id,
+        sq.rpt_period_id,
+        ROW_NUMBER() OVER (ORDER BY ss.queued_time) AS submission_queue_position 
+    FROM camdecmpsaux.submission_set ss 
+    JOIN camdecmpsaux.submission_queue sq
+        ON sq.submission_set_id = ss.submission_set_id 
+        AND sq.status_cd = 'QUEUED'
+    LEFT JOIN camdecmpswks.MONITOR_PLAN pln
+        ON pln.mon_plan_id = ss.mon_plan_id 
+    LEFT JOIN camdecmpswks.TEST_SUMMARY tst
+        ON tst.test_sum_id = sq.test_sum_id
+    LEFT JOIN camdecmpswks.QA_CERT_EVENT qce
+        ON qce.qa_cert_event_id = sq.qa_cert_event_id
+    LEFT JOIN camdecmpswks.TEST_EXTENSION_EXEMPTION tee
+        ON tee.test_extension_exemption_id = sq.test_extension_exemption_id
+    LEFT JOIN camdecmpswks.EMISSION_EVALUATION ems
+        ON ems.mon_plan_id = ss.mon_plan_id
+        AND ems.rpt_period_id = sq.rpt_period_id
+),
+ evaluation_ord AS (
     SELECT  
         evs.evaluation_set_id, 
         evq.evaluation_id,
@@ -72,15 +98,26 @@ SELECT p.oris_code,
             COALESCE(
                 'In Queue (#' || (
                     SELECT MIN(queue_position)
-                    FROM ord
-                    WHERE ord.test_sum_id = ts.test_sum_id 
+                    FROM evaluation_ord
+                    WHERE evaluation_ord.test_sum_id = ts.test_sum_id 
                 )::TEXT || ' in queue)',
                 esc.eval_status_cd_description
             )
         ELSE esc.eval_status_cd_description 
     END AS eval_status_cd_description,
     qsd.submission_availability_cd,
-    sac.sub_avail_cd_description as submission_availability_cd_description,
+    CASE 
+        WHEN sac.submission_availability_cd = 'PENDING' THEN 
+            COALESCE(
+                'Submitted, Host Update Pending (#' || (
+                    SELECT MIN(submission_queue_position) 
+                    FROM submission_ord 
+                    WHERE submission_ord.test_sum_id = ts.test_sum_id
+                )::TEXT || ' in queue)', 
+                sac.sub_avail_cd_description
+            )
+        ELSE sac.sub_avail_cd_description 
+    END AS submission_availability_cd_description,
     rp.period_abbreviation
    FROM camd.plant p
      JOIN camdecmpswks.monitor_plan mp USING (fac_id)


### PR DESCRIPTION
## Ticket
[Update Evaluation and Submission UI to Show Place in Queue](https://github.com/US-EPA-CAMD/easey-ui/issues/6619)


Note:
~~I noticed that the tables `camdecmpswks.test_extension_exemption`, `camdecmpswks.qa_cert_event`, `camdecmpswks.emission_evaluation`, and `camdecmpswks.monitor_plan` all have the **`submission_availability_cd`** column, but **`camdecmpswks.test_summary` does not**.~~