### PR TITLE
Feature/6515 MATS submission screen

### DIFF
--- a/camdecmpsaux/constraints-indexes/2-mats_data_submission_payload_file.sql
+++ b/camdecmpsaux/constraints-indexes/2-mats_data_submission_payload_file.sql
@@ -1,5 +1,6 @@
 ALTER TABLE IF EXISTS camdecmpsaux.mats_data_submission_payload_file
     ADD CONSTRAINT pk_mats_data_submission_payload_file PRIMARY KEY (mats_data_sub_payload_file_id),
+    ADD CONSTRAINT uq_mats_data_submission_payload_file UNIQUE (mats_data_sub_id, file_name),
     ADD CONSTRAINT fk_mats_data_submission_payload_file_mats_data_submission FOREIGN KEY (mats_data_sub_id) REFERENCES camdecmpsaux.mats_data_submission (mats_data_sub_id) MATCH simple ON DELETE CASCADE,
     ADD CONSTRAINT fk_mats_data_submission_payload_file_mats_data_file_type_code FOREIGN KEY (mats_data_file_type_cd) REFERENCES camdecmpsmd.mats_data_file_type_code (mats_data_file_type_cd) MATCH simple;
 

--- a/deployments/ecmps/release-v2.0-fix/Sprint20/6515/mats_data_submission_payload_file.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint20/6515/mats_data_submission_payload_file.sql
@@ -1,0 +1,3 @@
+ALTER TABLE IF EXISTS camdecmpsaux.mats_data_submission_payload_file
+    ADD CONSTRAINT uq_mats_data_submission_payload_file UNIQUE (mats_data_sub_id, file_name);
+


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6515

## Main Changes:

- Added a unique constraint to the CAMDECMPSAUX.MATS_DATA_SUBMISSION_PAYLOAD_FILE table on the related submission ID and the file name.