### PR TITLE
feat:update the camdecmpsaux.MATS_DATA_SUBMISSION table with user_email

### DIFF
--- a/camdecmpsaux/tables/mats_data_submission.sql
+++ b/camdecmpsaux/tables/mats_data_submission.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS camdecmpsaux.mats_data_submission (
     mon_plan_id varchar(45) COLLATE pg_catalog."default" NOT NULL,
     mats_status_cd varchar(8) COLLATE pg_catalog."default" NOT NULL DEFAULT 'NEW',
     user_id varchar(45) COLLATE pg_catalog."default" NOT NULL,
+    user_email varchar(100) COLLATE pg_catalog."default" NOT NULL,
     add_time timestamp without time zone NOT NULL,
     update_time timestamp without time zone
 );
@@ -75,4 +76,7 @@ COMMENT ON COLUMN camdecmpsaux.mats_data_submission.user_id IS 'User ID of the p
 COMMENT ON COLUMN camdecmpsaux.mats_data_submission.add_time IS 'Date and time the record was added to the system.';
 
 COMMENT ON COLUMN camdecmpsaux.mats_data_submission.update_time IS 'Date and time the record was last updated in the system.';
+
+COMMENT ON COLUMN camdecmpsaux.MATS_DATA_SUBMISSION.user_email IS 'Email address of the user who submitted the data';
+
 

--- a/deployments/ecmps/release-v2.0-fix/Sprint20/6513/update_user_email_mats_data_submission.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint20/6513/update_user_email_mats_data_submission.sql
@@ -1,0 +1,15 @@
+-- Add new column to the MATS_DATA_SUBMISSION table
+ALTER TABLE camdecmpsaux.MATS_DATA_SUBMISSION
+ADD COLUMN user_email VARCHAR(100) COLLATE pg_catalog."default";
+
+-- Add comments for the new columns
+COMMENT ON COLUMN camdecmpsaux.MATS_DATA_SUBMISSION.user_email IS 'Email address of the user who submitted the data';
+
+-- Update existing rows with default email (required before adding NOT NULL constraint)
+UPDATE camdecmpsaux.MATS_DATA_SUBMISSION
+SET user_email = 'null'
+WHERE user_email IS NULL;
+
+-- Now add the NOT NULL constraint
+ALTER TABLE camdecmpsaux.MATS_DATA_SUBMISSION
+ALTER COLUMN user_email SET NOT NULL;


### PR DESCRIPTION
## Ticket
[MATS Data Submission Processing](https://github.com/US-EPA-CAMD/easey-ui/issues/6513)

## Change

- Add a user_email column to the mats_data_submission table