### PR TITLE
Feature/6790 unnecessary locId parameter

### DIFF
--- a/camdecmpswks/functions/get_facility_units.sql
+++ b/camdecmpswks/functions/get_facility_units.sql
@@ -1,0 +1,21 @@
+-- FUNCTION: camdecmpswks.get_facility_units(integer[])
+
+DROP FUNCTION IF EXISTS camdecmpswks.get_facility_units (integer[]) CASCADE;
+
+CREATE OR REPLACE FUNCTION camdecmpswks.get_facility_units (oriscodes integer[])
+    RETURNS SETOF numeric
+    LANGUAGE 'plpgsql'
+    COST 100 VOLATILE ROWS 1000
+    AS $BODY$
+BEGIN
+    RETURN query
+    SELECT
+        unit_id
+    FROM
+        camd.plant
+        JOIN camd.unit USING (fac_id)
+    WHERE
+        oris_code = ANY (orisCodes);
+END;
+$BODY$;
+

--- a/deployments/ecmps/release-v2.0-fix/Sprint25/6790/get_facility_units.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint25/6790/get_facility_units.sql
@@ -1,0 +1,21 @@
+-- FUNCTION: camdecmpswks.get_facility_units(integer[])
+
+DROP FUNCTION IF EXISTS camdecmpswks.get_facility_units (integer[]) CASCADE;
+
+CREATE OR REPLACE FUNCTION camdecmpswks.get_facility_units (oriscodes integer[])
+    RETURNS SETOF numeric
+    LANGUAGE 'plpgsql'
+    COST 100 VOLATILE ROWS 1000
+    AS $BODY$
+BEGIN
+    RETURN query
+    SELECT
+        unit_id
+    FROM
+        camd.plant
+        JOIN camd.unit USING (fac_id)
+    WHERE
+        oris_code = ANY (orisCodes);
+END;
+$BODY$;
+


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6790

## Main Changes:

- Added a `get_facility_units` function to be used in the **`RolesGuard`** alongside the other `get_facility_*` functions.