### PR TITLE
Change the FUEL_GROUP_CD to 'OTHER' for Coal Refuse (CRF) and Petrole…

### DIFF
--- a/camdecmpsmd/table-data/fuel_type_code.sql
+++ b/camdecmpsmd/table-data/fuel_type_code.sql
@@ -13,5 +13,5 @@ INSERT INTO camdecmpsmd.fuel_type_code (fuel_type_cd, fuel_type_description, fue
 INSERT INTO camdecmpsmd.fuel_type_code (fuel_type_cd, fuel_type_description, fuel_group_cd) VALUES ('W', 'Wood', 'OTHER');
 INSERT INTO camdecmpsmd.fuel_type_code (fuel_type_cd, fuel_type_description, fuel_group_cd) VALUES ('WL', 'Waste Liquid', 'OTHER');
 INSERT INTO camdecmpsmd.fuel_type_code (fuel_type_cd, fuel_type_description, fuel_group_cd) VALUES ('C', 'Coal', 'COAL');
-INSERT INTO camdecmpsmd.fuel_type_code (fuel_type_cd, fuel_type_description, fuel_group_cd) VALUES ('CRF', 'Coal Refuse', 'COAL');
-INSERT INTO camdecmpsmd.fuel_type_code (fuel_type_cd, fuel_type_description, fuel_group_cd) VALUES ('PTC', 'Petroleum Coke', 'COAL');
+INSERT INTO camdecmpsmd.fuel_type_code (fuel_type_cd, fuel_type_description, fuel_group_cd) VALUES ('CRF', 'Coal Refuse', 'OTHER');
+INSERT INTO camdecmpsmd.fuel_type_code (fuel_type_cd, fuel_type_description, fuel_group_cd) VALUES ('PTC', 'Petroleum Coke', 'OTHER');

--- a/deployments/ecmps/release-v2.0-fix/Sprint25/6793/camdecmpsmd/table-data/update_fuel_type_code.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint25/6793/camdecmpsmd/table-data/update_fuel_type_code.sql
@@ -1,0 +1,7 @@
+-- Changed FUEL_GROUP_CD from 'COAL' to 'OTHER' for:  
+        -- CRF (Coal Refuse)  
+        -- PTC (Petroleum Coke)  
+
+UPDATE camdecmpsmd.fuel_type_code
+SET fuel_group_cd = 'OTHER'
+WHERE fuel_type_cd IN ('CRF', 'PTC');


### PR DESCRIPTION
## Ticket
[Correct Fuel Group Codes in the Fuel Type Code Table](https://github.com/US-EPA-CAMD/easey-ui/issues/6793)

## Change

- Change the FUEL_GROUP_CD to 'OTHER' for Coal Refuse (CRF) and Petroleum Coke (PTC) in the FUEL_TYPE_CODE table.