### PR TITLE
Required Resubmission windows are now automatically be extended

### DIFF
--- a/camdecmpsaux/views/vw_submission_window_job_close.sql
+++ b/camdecmpsaux/views/vw_submission_window_job_close.sql
@@ -32,8 +32,7 @@ select
 		else 'F'
 	end as CHECK_FOR_REMINDER,
 	case
-		when ESA.EM_SUB_TYPE_CD = 'INITIAL' OR 
-			S.STATUS_CD IN ('NOLOAD', 'RECCRIT') OR
+		when S.STATUS_CD IN ('NOLOAD', 'RECCRIT') OR
 			S.SEVERITY_CD = 'CRIT2' then 'T'
 		else 'F'
 	end as EXTEND_WINDOW	

--- a/deployments/ecmps/release-v2.0-fix/Sprint26/6610/camdecmpsaux/vw_submission_window_job_close.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint26/6610/camdecmpsaux/vw_submission_window_job_close.sql
@@ -30,8 +30,7 @@ select
 		else 'F'
 	end as CHECK_FOR_REMINDER,
 	case
-		when ESA.EM_SUB_TYPE_CD = 'INITIAL' OR 
-			S.STATUS_CD IN ('NOLOAD', 'RECCRIT') OR
+		when S.STATUS_CD IN ('NOLOAD', 'RECCRIT') OR
 			S.SEVERITY_CD = 'CRIT2' then 'T'
 		else 'F'
 	end as EXTEND_WINDOW	


### PR DESCRIPTION
Required Resubmission windows are now automatically be extended, instead of closed, when a file has not yet been resubmitted. Updated camdecmpsaux.vw_submission_window_job_close