### PR TITLE
Feature/6864 evaluate multiple quarters EM

### DIFF
--- a/camdecmpswks/views/vw_em_evaluate.sql
+++ b/camdecmpswks/views/vw_em_evaluate.sql
@@ -1,0 +1,10 @@
+-- View: camdecmpswks.vw_em_evaluate
+-- This view currently expects the same results as the camdecmpswks.vw_em_export_and_report view, so to avoid duplication and the chance of errors, it simply selects all columns from that view.
+DROP VIEW IF EXISTS camdecmpswks.vw_em_evaluate;
+
+CREATE OR REPLACE VIEW camdecmpswks.vw_em_evaluate AS
+SELECT
+    *
+FROM
+    camdecmpswks.vw_em_export_and_report;
+

--- a/deployments/ecmps/release-v2.0-fix/Sprint26/6864/vw_em_evaluate.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint26/6864/vw_em_evaluate.sql
@@ -1,0 +1,8 @@
+-- View: camdecmpswks.vw_em_evaluate
+-- This view currently expects the same results as the camdecmpswks.vw_em_export_and_report view, so to avoid duplication and the chance of errors, it simply selects all columns from that view.
+CREATE OR REPLACE VIEW camdecmpswks.vw_em_evaluate AS
+SELECT
+    *
+FROM
+    camdecmpswks.vw_em_export_and_report;
+


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6864

## Main Changes:

- Split off a dedicated view for retrieving EM records for evaluation. This is currently identical to the `camdecmpswks.vw_em_export_and_report` view, so it simply selects from that view.

## NOTE:

This branch was forked from `feature/6863-export_report_multiple_quarters_em`. If #178 is merged first, this PR should be updated to target the `develop` branch.