### PR TITLE
fix/#6743 Test Quarterly EM Submission Windows Report

### DIFF
--- a/camdecmpsaux/functions/get_quarterly_em_submission_windows_report_data.sql
+++ b/camdecmpsaux/functions/get_quarterly_em_submission_windows_report_data.sql
@@ -1,7 +1,7 @@
 DROP FUNCTION IF EXISTS camdecmpsaux.get_quarterly_em_submission_windows_report_data(numeric, character varying, character varying, numeric, numeric) CASCADE;
 
 CREATE OR REPLACE FUNCTION camdecmpsaux.get_quarterly_em_submission_windows_report_data(
-    V_FAC_ID            numeric,
+    V_ORIS_CODE         numeric,
     V_FACILITY_NAME     character varying,
     V_SUBMISSION_STATUS character varying,
     V_YEAR              numeric,
@@ -67,7 +67,7 @@ BEGIN
         V.SEVERITY_CD_DESCRIPTION,
         V.SUBMITTER_USER_ID
     FROM camdecmpsaux.vw_em_submission_access V
-    WHERE V.FAC_ID = COALESCE(V_FAC_ID, V.FAC_ID)
+    WHERE V.ORIS_CODE = COALESCE(V_ORIS_CODE, V.ORIS_CODE)
       AND V.FACILITY_NAME = COALESCE(V_FACILITY_NAME, V.FACILITY_NAME)
       AND V.RPT_PERIOD_ID = COALESCE(V_RPT_PERIOD_ID, V.RPT_PERIOD_ID)
       AND V.SUBMISSION_STATUS = COALESCE(V_SUBMISSION_STATUS, V.SUBMISSION_STATUS)

--- a/deployments/ecmps/release-v2.0-fix/Sprint24/6743/camdecmpsaux/get_quarterly_em_submission_windows_report_data.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint24/6743/camdecmpsaux/get_quarterly_em_submission_windows_report_data.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION camdecmpsaux.get_quarterly_em_submission_windows_report_data(
-    V_FAC_ID            numeric,
+    V_ORIS_CODE         numeric,
     V_FACILITY_NAME     character varying,
     V_SUBMISSION_STATUS character varying,
     V_YEAR              numeric,
@@ -65,7 +65,7 @@ BEGIN
         V.SEVERITY_CD_DESCRIPTION,
         V.SUBMITTER_USER_ID
     FROM camdecmpsaux.vw_em_submission_access V
-    WHERE V.FAC_ID = COALESCE(V_FAC_ID, V.FAC_ID)
+    WHERE V.ORIS_CODE = COALESCE(V_ORIS_CODE, V.ORIS_CODE)
       AND V.FACILITY_NAME = COALESCE(V_FACILITY_NAME, V.FACILITY_NAME)
       AND V.RPT_PERIOD_ID = COALESCE(V_RPT_PERIOD_ID, V.RPT_PERIOD_ID)
       AND V.SUBMISSION_STATUS = COALESCE(V_SUBMISSION_STATUS, V.SUBMISSION_STATUS)


### PR DESCRIPTION
## Related Ticket:

- ticket [#6743](https://github.com/US-EPA-CAMD/easey-ui/issues/6743)

## Updates:

- update the passed in parameter v_fac_id to v_oris_code for the camdecmpsaux.get_quarterly_em_submission_windows_report_data function