### PR TITLE
Fix/#6904 contacts analyst links

### DIFF
--- a/camdecmpsaux/tables/email_template.sql
+++ b/camdecmpsaux/tables/email_template.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS camdecmpsaux.email_template
 (
     template_id integer NOT NULL,
-    template_location character varying(200) COLLATE pg_catalog."default" NOT NULL,
-    template_subject text COLLATE pg_catalog."default"
+    template_location character varying(500) COLLATE pg_catalog."default" NOT NULL,
+    template_subject text COLLATE pg_catalog."default",
+    template_description text COLLATE pg_catalog."default"
 );

--- a/deployments/ecmps/release-v2.0-fix/Sprint27/6886/camdecmpsaux/email_template.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint27/6886/camdecmpsaux/email_template.sql
@@ -1,0 +1,45 @@
+ALTER TABLE camdecmpsaux.email_template
+ALTER COLUMN template_location TYPE varchar(500) COLLATE pg_catalog."default",
+  ADD COLUMN template_description text COLLATE pg_catalog."default";
+
+-- Update existing template locations to the new reorganized format
+UPDATE camdecmpsaux.email_template
+SET template_location = 'email/submission-reminder/submission-reminder-not-received-151.html',
+    template_description = 'Reminder email sent to users when no submission has been received by the deadline'
+WHERE template_id = 151;
+
+UPDATE camdecmpsaux.email_template
+SET template_location = 'email/submission-reminder/submission-reminder-resubmit-errors-152.html',
+    template_description = 'Reminder email sent to users to resubmit data with errors that need correction'
+WHERE template_id = 152;
+
+UPDATE camdecmpsaux.email_template
+SET template_location = 'email/window-notification/submission-window-open-155.html',
+    template_description = 'Notification email sent when the quarterly submission window opens for data submissions'
+WHERE template_id = 155;
+
+UPDATE camdecmpsaux.email_template
+SET template_location = 'email/submission-reminder/submission-reminder-past-due-156.html',
+    template_description = 'Reminder email sent to users when their submission is past due and overdue'
+WHERE template_id = 156;
+
+UPDATE camdecmpsaux.email_template
+SET template_location = 'email/window-notification/resubmission-window-closed-157.html',
+    template_description = 'Notification email sent when the resubmission window has closed for the quarter'
+WHERE template_id = 157;
+
+-- Delete unused template_id 150
+DELETE FROM camdecmpsaux.email_template
+WHERE template_id = 150;
+
+-- Insert the new template configurations
+INSERT INTO camdecmpsaux.email_template (template_id, template_location, template_subject, template_description)
+VALUES
+    (200, 'email/submissions/confirmation/submission-confirmation.hbs', NULL, 'Main submission confirmation email sent to users'),
+    (201, 'email/submissions/feedback/submission-feedback.hbs', NULL, 'Detailed submission feedback with evaluation results'),
+    (202, 'email/submissions/errors/submission-failure-user.hbs', NULL, 'Submission processing failure email to Users'),
+    (203, 'email/submissions/errors/submission-failure-support.hbs', NULL, 'Submission processing failure email to Support team'),
+    (204, 'email/submissions/errors/queueing-failure-user.hbs', NULL, 'Submission queueing failure email to Users'),
+    (205, 'email/submissions/errors/queueing-failure-support.hbs', NULL, 'Submission queueing failure email to Support team'),
+    (206, 'email/evaluations/mass-evaluation.hbs', NULL, 'Mass evaluation results and reports'),
+    (207, 'email/submissions/mats/mats-submission.hbs', NULL, 'MATS file submission confirmation');

--- a/deployments/ecmps/release-v2.0-fix/Sprint27/6886/camdecmpsaux/email_template.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint27/6886/camdecmpsaux/email_template.sql
@@ -39,7 +39,9 @@ VALUES
     (201, 'templates/email/submissions/feedback/submission-feedback.hbs', NULL, 'Detailed submission feedback with evaluation results'),
     (202, 'templates/email/submissions/errors/submission-failure-user.hbs', NULL, 'Submission processing failure email to Users'),
     (203, 'templates/email/submissions/errors/submission-failure-support.hbs', NULL, 'Submission processing failure email to Support team'),
-    (204, 'templates/email/submissions/errors/queueing-failure-user.hbs', NULL, 'Submission queueing failure email to Users'),
-    (205, 'templates/email/submissions/errors/queueing-failure-support.hbs', NULL, 'Submission queueing failure email to Support team'),
+    (204, 'templates/email/evaluations/evaluation-queueing-failure-user.hbs', NULL, 'Evaluation queueing failure email to Users'),
+    (205, 'templates/email/evaluations/evaluation-queueing-failure-support.hbs', NULL, 'Evaluation queueing failure email to Support team'),
     (206, 'templates/email/evaluations/mass-evaluation.hbs', NULL, 'Mass evaluation results and reports'),
     (207, 'templates/email/submissions/mats/mats-submission.hbs', NULL, 'MATS file submission confirmation');
+    (208, 'templates/email/submissions/errors/submission-queueing-failure-user.hbs', NULL, 'Submission queueing failure email to Users'),
+    (209, 'templates/email/submissions/errors/submission-queueing-failure-support.hbs', NULL, 'Submission queueing failure email to Support team');

--- a/deployments/ecmps/release-v2.0-fix/Sprint27/6886/camdecmpsaux/email_template.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint27/6886/camdecmpsaux/email_template.sql
@@ -4,27 +4,27 @@ ALTER COLUMN template_location TYPE varchar(500) COLLATE pg_catalog."default",
 
 -- Update existing template locations to the new reorganized format
 UPDATE camdecmpsaux.email_template
-SET template_location = 'email/submission-reminder/submission-reminder-not-received-151.html',
+SET template_location = 'templates/email/submission-reminder/submission-reminder-not-received-151.html',
     template_description = 'Reminder email sent to users when no submission has been received by the deadline'
 WHERE template_id = 151;
 
 UPDATE camdecmpsaux.email_template
-SET template_location = 'email/submission-reminder/submission-reminder-resubmit-errors-152.html',
+SET template_location = 'templates/email/submission-reminder/submission-reminder-resubmit-errors-152.html',
     template_description = 'Reminder email sent to users to resubmit data with errors that need correction'
 WHERE template_id = 152;
 
 UPDATE camdecmpsaux.email_template
-SET template_location = 'email/window-notification/submission-window-open-155.html',
+SET template_location = 'templates/email/window-notification/submission-window-open-155.html',
     template_description = 'Notification email sent when the quarterly submission window opens for data submissions'
 WHERE template_id = 155;
 
 UPDATE camdecmpsaux.email_template
-SET template_location = 'email/submission-reminder/submission-reminder-past-due-156.html',
+SET template_location = 'templates/email/submission-reminder/submission-reminder-past-due-156.html',
     template_description = 'Reminder email sent to users when their submission is past due and overdue'
 WHERE template_id = 156;
 
 UPDATE camdecmpsaux.email_template
-SET template_location = 'email/window-notification/resubmission-window-closed-157.html',
+SET template_location = 'templates/email/window-notification/resubmission-window-closed-157.html',
     template_description = 'Notification email sent when the resubmission window has closed for the quarter'
 WHERE template_id = 157;
 
@@ -35,11 +35,11 @@ WHERE template_id = 150;
 -- Insert the new template configurations
 INSERT INTO camdecmpsaux.email_template (template_id, template_location, template_subject, template_description)
 VALUES
-    (200, 'email/submissions/confirmation/submission-confirmation.hbs', NULL, 'Main submission confirmation email sent to users'),
-    (201, 'email/submissions/feedback/submission-feedback.hbs', NULL, 'Detailed submission feedback with evaluation results'),
-    (202, 'email/submissions/errors/submission-failure-user.hbs', NULL, 'Submission processing failure email to Users'),
-    (203, 'email/submissions/errors/submission-failure-support.hbs', NULL, 'Submission processing failure email to Support team'),
-    (204, 'email/submissions/errors/queueing-failure-user.hbs', NULL, 'Submission queueing failure email to Users'),
-    (205, 'email/submissions/errors/queueing-failure-support.hbs', NULL, 'Submission queueing failure email to Support team'),
-    (206, 'email/evaluations/mass-evaluation.hbs', NULL, 'Mass evaluation results and reports'),
-    (207, 'email/submissions/mats/mats-submission.hbs', NULL, 'MATS file submission confirmation');
+    (200, 'templates/email/submissions/confirmation/submission-confirmation.hbs', NULL, 'Main submission confirmation email sent to users'),
+    (201, 'templates/email/submissions/feedback/submission-feedback.hbs', NULL, 'Detailed submission feedback with evaluation results'),
+    (202, 'templates/email/submissions/errors/submission-failure-user.hbs', NULL, 'Submission processing failure email to Users'),
+    (203, 'templates/email/submissions/errors/submission-failure-support.hbs', NULL, 'Submission processing failure email to Support team'),
+    (204, 'templates/email/submissions/errors/queueing-failure-user.hbs', NULL, 'Submission queueing failure email to Users'),
+    (205, 'templates/email/submissions/errors/queueing-failure-support.hbs', NULL, 'Submission queueing failure email to Support team'),
+    (206, 'templates/email/evaluations/mass-evaluation.hbs', NULL, 'Mass evaluation results and reports'),
+    (207, 'templates/email/submissions/mats/mats-submission.hbs', NULL, 'MATS file submission confirmation');

--- a/deployments/ecmps/release-v2.0/load-additional-mdm-data.sql
+++ b/deployments/ecmps/release-v2.0/load-additional-mdm-data.sql
@@ -120,15 +120,22 @@ INSERT INTO camdecmpsmd.test_type_group_code(
     ('MISC', 'Miscellaneous', 1);
 -----------------------------------------------------------------------
 TRUNCATE camdecmpsaux.email_template;
-INSERT INTO camdecmpsaux.email_template(
-  template_id, template_location, template_subject
-) VALUES
-  (150,	'templates/submission-confirmation.html', 'Submission Completion Notification'),
-  (151,	'templates/submission-151.html', 'Emissions Submission Reminder'),
-  (152,	'templates/submission-152.html', 'Emissions Submission Reminder'),
-  (155,	'templates/submission-155.html', 'Submission Window Open for Quarterly Emission File'),
-  (156,	'templates/submission-156.html', 'Outstanding Emissions Submission Reminder'),
-  (157,	'templates/submission-157.html', 'Emissions Resubmission Window Closed');
+INSERT INTO camdecmpsaux.email_template (template_id, template_location, template_subject, template_description)
+VALUES
+    (151, 'email/submission-reminder/submission-reminder-not-received-151.html', 'Emissions Submission Reminder', 'Reminder email sent to users when no submission has been received by the deadline'),
+    (152, 'email/submission-reminder/submission-reminder-resubmit-errors-152.html', 'Emissions Submission Reminder', 'Reminder email sent to users to resubmit data with errors that need correction'),
+    (155, 'email/window-notification/submission-window-open-155.html', 'Submission Window Open for Quarterly Emission File', 'Notification email sent when the quarterly submission window opens for data submissions'),
+    (156, 'email/submission-reminder/submission-reminder-past-due-156.html', 'Outstanding Emissions Submission Reminder', 'Reminder email sent to users when their submission is past due and overdue'),
+    (157, 'email/window-notification/resubmission-window-closed-157.html', 'Emissions Resubmission Window Closed', 'Notification email sent when the resubmission window has closed for the quarter');
+    (200, 'email/submissions/confirmation/submission-confirmation.hbs', NULL, 'Main submission confirmation email sent to users'),
+    (201, 'email/submissions/feedback/submission-feedback.hbs', NULL, 'Detailed submission feedback with evaluation results'),
+    (202, 'email/submissions/errors/submission-failure-user.hbs', NULL, 'Submission processing failure email to Users'),
+    (203, 'email/submissions/errors/submission-failure-support.hbs', NULL, 'Submission processing failure email to Support team'),
+    (204, 'email/submissions/errors/queueing-failure-user.hbs', NULL, 'Submission queueing failure email to Users'),
+    (205, 'email/submissions/errors/queueing-failure-support.hbs', NULL, 'Submission queueing failure email to Support team'),
+    (206, 'email/evaluations/mass-evaluation.hbs', NULL, 'Mass evaluation results and reports'),
+    (207, 'email/submissions/mats/mats-submission.hbs', NULL, 'MATS file submission confirmation');
+
 -----------------------------------------------------------------------
 TRUNCATE camdecmpswks.certification_statement;
 INSERT INTO camdecmpswks.certification_statement(statement_text, prg_cd)

--- a/deployments/ecmps/release-v2.0/load-additional-mdm-data.sql
+++ b/deployments/ecmps/release-v2.0/load-additional-mdm-data.sql
@@ -122,19 +122,19 @@ INSERT INTO camdecmpsmd.test_type_group_code(
 TRUNCATE camdecmpsaux.email_template;
 INSERT INTO camdecmpsaux.email_template (template_id, template_location, template_subject, template_description)
 VALUES
-    (151, 'email/submission-reminder/submission-reminder-not-received-151.html', 'Emissions Submission Reminder', 'Reminder email sent to users when no submission has been received by the deadline'),
-    (152, 'email/submission-reminder/submission-reminder-resubmit-errors-152.html', 'Emissions Submission Reminder', 'Reminder email sent to users to resubmit data with errors that need correction'),
-    (155, 'email/window-notification/submission-window-open-155.html', 'Submission Window Open for Quarterly Emission File', 'Notification email sent when the quarterly submission window opens for data submissions'),
-    (156, 'email/submission-reminder/submission-reminder-past-due-156.html', 'Outstanding Emissions Submission Reminder', 'Reminder email sent to users when their submission is past due and overdue'),
-    (157, 'email/window-notification/resubmission-window-closed-157.html', 'Emissions Resubmission Window Closed', 'Notification email sent when the resubmission window has closed for the quarter');
-    (200, 'email/submissions/confirmation/submission-confirmation.hbs', NULL, 'Main submission confirmation email sent to users'),
-    (201, 'email/submissions/feedback/submission-feedback.hbs', NULL, 'Detailed submission feedback with evaluation results'),
-    (202, 'email/submissions/errors/submission-failure-user.hbs', NULL, 'Submission processing failure email to Users'),
-    (203, 'email/submissions/errors/submission-failure-support.hbs', NULL, 'Submission processing failure email to Support team'),
-    (204, 'email/submissions/errors/queueing-failure-user.hbs', NULL, 'Submission queueing failure email to Users'),
-    (205, 'email/submissions/errors/queueing-failure-support.hbs', NULL, 'Submission queueing failure email to Support team'),
-    (206, 'email/evaluations/mass-evaluation.hbs', NULL, 'Mass evaluation results and reports'),
-    (207, 'email/submissions/mats/mats-submission.hbs', NULL, 'MATS file submission confirmation');
+    (151, 'templates/email/submission-reminder/submission-reminder-not-received-151.html', 'Emissions Submission Reminder', 'Reminder email sent to users when no submission has been received by the deadline'),
+    (152, 'templates/email/submission-reminder/submission-reminder-resubmit-errors-152.html', 'Emissions Submission Reminder', 'Reminder email sent to users to resubmit data with errors that need correction'),
+    (155, 'templates/email/window-notification/submission-window-open-155.html', 'Submission Window Open for Quarterly Emission File', 'Notification email sent when the quarterly submission window opens for data submissions'),
+    (156, 'templates/email/submission-reminder/submission-reminder-past-due-156.html', 'Outstanding Emissions Submission Reminder', 'Reminder email sent to users when their submission is past due and overdue'),
+    (157, 'templates/email/window-notification/resubmission-window-closed-157.html', 'Emissions Resubmission Window Closed', 'Notification email sent when the resubmission window has closed for the quarter');
+    (200, 'templates/email/submissions/confirmation/submission-confirmation.hbs', NULL, 'Main submission confirmation email sent to users'),
+    (201, 'templates/email/submissions/feedback/submission-feedback.hbs', NULL, 'Detailed submission feedback with evaluation results'),
+    (202, 'templates/email/submissions/errors/submission-failure-user.hbs', NULL, 'Submission processing failure email to Users'),
+    (203, 'templates/email/submissions/errors/submission-failure-support.hbs', NULL, 'Submission processing failure email to Support team'),
+    (204, 'templates/email/submissions/errors/queueing-failure-user.hbs', NULL, 'Submission queueing failure email to Users'),
+    (205, 'templates/email/submissions/errors/queueing-failure-support.hbs', NULL, 'Submission queueing failure email to Support team'),
+    (206, 'templates/email/evaluations/mass-evaluation.hbs', NULL, 'Mass evaluation results and reports'),
+    (207, 'templates/email/submissions/mats/mats-submission.hbs', NULL, 'MATS file submission confirmation');
 
 -----------------------------------------------------------------------
 TRUNCATE camdecmpswks.certification_statement;

--- a/deployments/ecmps/release-v2.0/load-additional-mdm-data.sql
+++ b/deployments/ecmps/release-v2.0/load-additional-mdm-data.sql
@@ -131,10 +131,13 @@ VALUES
     (201, 'templates/email/submissions/feedback/submission-feedback.hbs', NULL, 'Detailed submission feedback with evaluation results'),
     (202, 'templates/email/submissions/errors/submission-failure-user.hbs', NULL, 'Submission processing failure email to Users'),
     (203, 'templates/email/submissions/errors/submission-failure-support.hbs', NULL, 'Submission processing failure email to Support team'),
-    (204, 'templates/email/submissions/errors/queueing-failure-user.hbs', NULL, 'Submission queueing failure email to Users'),
-    (205, 'templates/email/submissions/errors/queueing-failure-support.hbs', NULL, 'Submission queueing failure email to Support team'),
+    (204, 'templates/email/evaluations/evaluation-queueing-failure-user.hbs', NULL, 'Evaluation queueing failure email to Users'),
+    (205, 'templates/email/evaluations/evaluation-queueing-failure-support.hbs', NULL, 'Evaluation queueing failure email to Support team'),
     (206, 'templates/email/evaluations/mass-evaluation.hbs', NULL, 'Mass evaluation results and reports'),
     (207, 'templates/email/submissions/mats/mats-submission.hbs', NULL, 'MATS file submission confirmation');
+    (208, 'templates/email/submissions/errors/submission-queueing-failure-user.hbs', NULL, 'Submission queueing failure email to Users'),
+    (209, 'templates/email/submissions/errors/submission-queueing-failure-support.hbs', NULL, 'Submission queueing failure email to Support team');
+
 
 -----------------------------------------------------------------------
 TRUNCATE camdecmpswks.certification_statement;


### PR DESCRIPTION
Updated the CAMD Staff Contacts link needs to be updated from https://dev.epacdx.net/ to https://www.epa.gov/power-sector/key-program-dates-contacts#MonitoringContacts
- refactored evaluation error template to correct location