### PR TITLE
Fix/6908 protocol gas transaction

### DIFF
--- a/deployments/ecmps/release-v2.0-fix/Sprint28/6908/copy_qa_test_summary_from_workspace_to_global.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint28/6908/copy_qa_test_summary_from_workspace_to_global.sql
@@ -1,7 +1,5 @@
 -- PROCEDURE: camdecmps.copy_qa_test_summary_from_workspace_to_global(character varying)
 
-DROP PROCEDURE IF EXISTS camdecmps.copy_qa_test_summary_from_workspace_to_global(character varying);
-
 CREATE OR REPLACE PROCEDURE camdecmps.copy_qa_test_summary_from_workspace_to_global(
 	testsumid character varying)
 LANGUAGE 'plpgsql'
@@ -974,3 +972,4 @@ ON CONFLICT (on_off_cal_id) DO UPDATE
     DELETE FROM camdecmpswks.test_summary WHERE test_sum_id = testSumId;
 END;
 $BODY$;
+


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6908

## Main Changes:

-  When copying test summaries to official, moved the deletion of existing protocol gas records inside the `copy_qa_test_summary_from_workspace_to_global`, rather than in a separate step of the submission process.