### PR TITLE
#6931-Generic Cross Check Value Table: Add Unique Constraint

### DIFF
--- a/camdecmpsmd/constraints-indexes/3-cross_check_catalog_value.sql
+++ b/camdecmpsmd/constraints-indexes/3-cross_check_catalog_value.sql
@@ -1,5 +1,6 @@
 ALTER TABLE IF EXISTS camdecmpsmd.cross_check_catalog_value
     ADD CONSTRAINT pk_cross_check_catalog_value PRIMARY KEY (cross_chk_catalog_value_id),
+	ADD CONSTRAINT uq_cross_check_catalog_value UNIQUE (cross_chk_catalog_id,value1,value2,value3),
     ADD CONSTRAINT fk_cross_check_catalog_value_cross_check_catalog FOREIGN KEY (cross_chk_catalog_id)
         REFERENCES camdecmpsmd.cross_check_catalog (cross_chk_catalog_id) MATCH SIMPLE;
 

--- a/camdecmpsmd/table-data/cross_check_catalog_value.sql
+++ b/camdecmpsmd/table-data/cross_check_catalog_value.sql
@@ -78,6 +78,7 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (109, 8, 'HI', 'AD', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (110, 8, 'HI', 'ADCALC', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (111, 8, 'SO2', 'AD', NULL);
+INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (112, 16, 'CO2', 'CO2W', 'F-11');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (113, 16, 'CO2', 'CO2D', 'F-2');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (114, 16, 'CO2C', 'O2W', 'F-14B');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (115, 16, 'CO2C', 'O2D', 'F-14A');
@@ -119,6 +120,7 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (153, 16, 'HI', 'GFFM', 'F-20');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (154, 16, 'OILM', 'OFFM', 'D-3');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (155, 16, 'SO2', 'OFFM', 'D-2');
+INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (156, 16, 'SO2', 'GFFM', 'D-4');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (157, 16, 'SO2', 'GFFM', 'D-5');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (159, 16, 'CO2', 'GFFM', 'G-4');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (161, 17, 'CO2', 'HI', NULL);
@@ -346,6 +348,7 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (437, 16, 'CO2', 'O2B', 'F-2');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (438, 16, 'CO2C', 'O2B', 'F-14A');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (439, 16, 'CO2C', 'O2B', 'F-14B');
+INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (440, 16, 'HI', 'O2B', 'F-17');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (441, 16, 'HI', 'O2B', 'F-18');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (472, 11, 'CO2', 'FORMULA', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (473, 11, 'CO2C', 'FORMULA', NULL);
@@ -408,8 +411,10 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (530, 33, 'LINE', 'O2', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (531, 33, 'RATA', NULL, 'NOXP');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (532, 16, 'CO2', NULL, 'G-4A');
+INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (534, 16, 'CO2M', NULL, 'G-1');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (535, 16, 'CO2M', NULL, 'G-2');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (536, 16, 'CO2M', NULL, 'G-3');
+INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (537, 16, 'CO2M', NULL, 'G-5');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (538, 16, 'CO2M', NULL, 'G-6');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (539, 16, 'CO2M', NULL, 'G-8');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (540, 16, 'FC', NULL, 'F-7B');
@@ -1128,22 +1133,18 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1396, 23, 'HG', 'H', 'TR');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1399, 16, 'HGRE', 'HGD', 'A-3');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1400, 16, 'HGRE', 'HGW', 'A-2');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1401, 16, 'CO2', 'CO2W', 'F-11');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1403, 16, 'HI', 'O2B', 'F-17');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1404, 16, 'HGRH', 'HGW', '19-2');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1405, 16, 'HGRH', 'HGW', '19-3');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1406, 16, 'HGRH', 'HGW', '19-4');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1407, 16, 'CO2M', NULL, 'G-1');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1408, 16, 'HGRH', 'HGW', '19-8');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1409, 16, 'HGRH', 'HGD', '19-1');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1410, 16, 'CO2M', NULL, 'G-5');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1411, 16, 'HGRH', 'HGD', '19-6');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1412, 16, 'HGRH', 'HGD', '19-9');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1413, 16, 'HGRH', 'STRAIND', '19-1');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1414, 16, 'HGRH', 'STRAIND', '19-5');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1415, 16, 'HGRH', 'STRAIND', '19-9');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1416, 16, 'HGRH', 'STRAIND', '19-6');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1418, 16, 'SO2', 'GFFM', 'D-4');
+INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1417, 16, 'HGRH', 'CO2D', '19-6');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1419, 16, 'HGRH', 'O2D', '19-1');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1420, 16, 'HGRH', 'O2D', '19-4');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1421, 16, 'HGRH', 'O2W', '19-2');
@@ -1233,15 +1234,13 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1510, 16, 'HCLRH', 'O2W', '19-2');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1511, 16, 'HCLRH', 'O2W', '19-3');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1512, 16, 'HCLRH', 'O2W', '19-5');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1513, 16, 'HGRH', 'CO2D', '19-6');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1514, 16, 'HFRH', 'CO2D', '19-6');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1515, 16, 'HFRH', 'CO2D', '19-8');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1516, 16, 'HFRH', 'CO2W', '19-7');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1517, 16, 'HFRH', 'CO2W', '19-9');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1518, 16, 'HFRH', 'O2B', '19-1');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1519, 16, 'HFRH', 'O2B', '19-2');
-
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1521, 16, 'HFRH', 'O2B', '19-3');
+INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1520, 16, 'HFRH', 'O2B', '19-3');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1522, 16, 'HFRH', 'O2B', '19-4');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1524, 16, 'HFRH', 'O2D', '19-1');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1525, 16, 'HFRH', 'O2D', '19-4');
@@ -2456,3 +2455,4 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (9337, 28, 'NOCX', 'MAXD', null);
 
+INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (9320, 193, 'SORX', 'PNG', NULL);

--- a/camdecmpsmd/table-data/cross_check_catalog_value.sql
+++ b/camdecmpsmd/table-data/cross_check_catalog_value.sql
@@ -2461,3 +2461,13 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (9336, 190, 'PM', 'W', null);
 
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (9337, 28, 'NOCX', 'MAXD', null);
+--delete the dup records--------
+delete from camdecmpsmd.CROSS_CHECK_CATALOG_VALUE
+where cross_chk_catalog_value_id in
+(select cross_chk_catalog_value_id from (select min(cross_chk_catalog_value_id) cross_chk_catalog_value_id,
+   cross_chk_catalog_id, value1, value2, value3
+   from camdecmpsmd.CROSS_CHECK_CATALOG_VALUE 
+   group  by  cross_chk_catalog_id,value1, value2,value3
+   having  count( * ) > 1 
+ order by cross_chk_catalog_id, value1, value2, value3) 
+ val);

--- a/camdecmpsmd/table-data/cross_check_catalog_value.sql
+++ b/camdecmpsmd/table-data/cross_check_catalog_value.sql
@@ -78,7 +78,6 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (109, 8, 'HI', 'AD', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (110, 8, 'HI', 'ADCALC', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (111, 8, 'SO2', 'AD', NULL);
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (112, 16, 'CO2', 'CO2W', 'F-11');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (113, 16, 'CO2', 'CO2D', 'F-2');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (114, 16, 'CO2C', 'O2W', 'F-14B');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (115, 16, 'CO2C', 'O2D', 'F-14A');
@@ -120,7 +119,6 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (153, 16, 'HI', 'GFFM', 'F-20');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (154, 16, 'OILM', 'OFFM', 'D-3');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (155, 16, 'SO2', 'OFFM', 'D-2');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (156, 16, 'SO2', 'GFFM', 'D-4');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (157, 16, 'SO2', 'GFFM', 'D-5');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (159, 16, 'CO2', 'GFFM', 'G-4');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (161, 17, 'CO2', 'HI', NULL);
@@ -348,7 +346,6 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (437, 16, 'CO2', 'O2B', 'F-2');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (438, 16, 'CO2C', 'O2B', 'F-14A');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (439, 16, 'CO2C', 'O2B', 'F-14B');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (440, 16, 'HI', 'O2B', 'F-17');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (441, 16, 'HI', 'O2B', 'F-18');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (472, 11, 'CO2', 'FORMULA', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (473, 11, 'CO2C', 'FORMULA', NULL);
@@ -411,10 +408,8 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (530, 33, 'LINE', 'O2', NULL);
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (531, 33, 'RATA', NULL, 'NOXP');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (532, 16, 'CO2', NULL, 'G-4A');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (534, 16, 'CO2M', NULL, 'G-1');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (535, 16, 'CO2M', NULL, 'G-2');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (536, 16, 'CO2M', NULL, 'G-3');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (537, 16, 'CO2M', NULL, 'G-5');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (538, 16, 'CO2M', NULL, 'G-6');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (539, 16, 'CO2M', NULL, 'G-8');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (540, 16, 'FC', NULL, 'F-7B');
@@ -1148,7 +1143,6 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1414, 16, 'HGRH', 'STRAIND', '19-5');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1415, 16, 'HGRH', 'STRAIND', '19-9');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1416, 16, 'HGRH', 'STRAIND', '19-6');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1417, 16, 'HGRH', 'CO2D', '19-6');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1418, 16, 'SO2', 'GFFM', 'D-4');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1419, 16, 'HGRH', 'O2D', '19-1');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1420, 16, 'HGRH', 'O2D', '19-4');
@@ -1246,7 +1240,7 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1517, 16, 'HFRH', 'CO2W', '19-9');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1518, 16, 'HFRH', 'O2B', '19-1');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1519, 16, 'HFRH', 'O2B', '19-2');
-INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1520, 16, 'HFRH', 'O2B', '19-3');
+
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1521, 16, 'HFRH', 'O2B', '19-3');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1522, 16, 'HFRH', 'O2B', '19-4');
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (1524, 16, 'HFRH', 'O2D', '19-1');
@@ -2461,13 +2455,4 @@ INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, c
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (9336, 190, 'PM', 'W', null);
 
 INSERT INTO camdecmpsmd.cross_check_catalog_value (cross_chk_catalog_value_id, cross_chk_catalog_id, value1, value2, value3) OVERRIDING SYSTEM VALUE VALUES (9337, 28, 'NOCX', 'MAXD', null);
---delete the dup records--------
-delete from camdecmpsmd.CROSS_CHECK_CATALOG_VALUE
-where cross_chk_catalog_value_id in
-(select cross_chk_catalog_value_id from (select min(cross_chk_catalog_value_id) cross_chk_catalog_value_id,
-   cross_chk_catalog_id, value1, value2, value3
-   from camdecmpsmd.CROSS_CHECK_CATALOG_VALUE 
-   group  by  cross_chk_catalog_id,value1, value2,value3
-   having  count( * ) > 1 
- order by cross_chk_catalog_id, value1, value2, value3) 
- val);
+

--- a/deployments/ecmps/release-v2.0-fix/Sprint29/6931/add uq constraint for cross_check_catalog_value.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint29/6931/add uq constraint for cross_check_catalog_value.sql
@@ -1,0 +1,2 @@
+alter table camdecmpsmd.cross_check_catalog_value
+ add CONSTRAINT uq_cross_check_catalog_value UNIQUE (cross_chk_catalog_id,value1,value2,value3);

--- a/deployments/ecmps/release-v2.0-fix/Sprint29/6931/delete dup for CROSS_CHECK_CATALOG_VALUE.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint29/6931/delete dup for CROSS_CHECK_CATALOG_VALUE.sql
@@ -1,13 +1,5 @@
--- to check the duplicates
-select cross_chk_catalog_value_id
-from (select min(cross_chk_catalog_value_id) cross_chk_catalog_value_id,
-cross_chk_catalog_id, value1, value2, value3
-from camdecmpsmd.CROSS_CHECK_CATALOG_VALUE 
- group  by  cross_chk_catalog_id,value1, value2,value3
-having  count( * ) > 1 
- order by cross_chk_catalog_id, value1, value2, value3) dal;
- 
  --delete current existing duplicates records 
- delete from camdecmpsmd.CROSS_CHECK_CATALOG_VALUE
-	where cross_chk_catalog_value_id in (112, 534,537,1520,1417, 440, 156, 9320);
+delete
+  from  camdecmpsmd.CROSS_CHECK_CATALOG_VALUE
+ where  cross_chk_catalog_value_id in ( 1401, 1403, 1407, 1410, 1418, 1513, 1521, 9325 );
 

--- a/deployments/ecmps/release-v2.0-fix/Sprint29/6931/delete dup for CROSS_CHECK_CATALOG_VALUE.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint29/6931/delete dup for CROSS_CHECK_CATALOG_VALUE.sql
@@ -1,9 +1,13 @@
-delete from camdecmpsmd.CROSS_CHECK_CATALOG_VALUE
-where cross_chk_catalog_value_id in
-(select cross_chk_catalog_value_id
+-- to check the duplicates
+select cross_chk_catalog_value_id
 from (select min(cross_chk_catalog_value_id) cross_chk_catalog_value_id,
 cross_chk_catalog_id, value1, value2, value3
 from camdecmpsmd.CROSS_CHECK_CATALOG_VALUE 
  group  by  cross_chk_catalog_id,value1, value2,value3
 having  count( * ) > 1 
- order by cross_chk_catalog_id, value1, value2, value3) val);
+ order by cross_chk_catalog_id, value1, value2, value3) dal;
+ 
+ --delete current existing duplicates records 
+ delete from camdecmpsmd.CROSS_CHECK_CATALOG_VALUE
+	where cross_chk_catalog_value_id in (112, 534,537,1520,1417, 440, 156, 9320);
+

--- a/deployments/ecmps/release-v2.0-fix/Sprint29/6931/delete dup for CROSS_CHECK_CATALOG_VALUE.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint29/6931/delete dup for CROSS_CHECK_CATALOG_VALUE.sql
@@ -1,0 +1,9 @@
+delete from camdecmpsmd.CROSS_CHECK_CATALOG_VALUE
+where cross_chk_catalog_value_id in
+(select cross_chk_catalog_value_id
+from (select min(cross_chk_catalog_value_id) cross_chk_catalog_value_id,
+cross_chk_catalog_id, value1, value2, value3
+from camdecmpsmd.CROSS_CHECK_CATALOG_VALUE 
+ group  by  cross_chk_catalog_id,value1, value2,value3
+having  count( * ) > 1 
+ order by cross_chk_catalog_id, value1, value2, value3) val);


### PR DESCRIPTION
## Changes

1. Of the seven duplicates identified in the ticket, removed the more recently added version (higher cross_chk_catalog_value_id) from the main script and in deployment script,
2. Added cross_chk_catalog_value_id of 9320 to the main script.  Both it and its duplicate (9325) were not in the script.
3. Anna, previously added to unique constraint to the main script and deployment script.