### PR TITLE
#6666 Correcting duplicate rows and Period Description issues, and correcting for list of reporting period ids for multiple years.

### DIFF
--- a/camdecmps/functions/rpt_em_emission_view_summary.sql
+++ b/camdecmps/functions/rpt_em_emission_view_summary.sql
@@ -2,13 +2,15 @@
 
 -- DROP FUNCTION IF EXISTS camdecmps.rpt_em_emission_view_summary(text, text, text);
 
-CREATE OR REPLACE FUNCTION camdecmps.rpt_em_emission_view_summary(
-	monitorPlanId text,
-	locationId text,
-	reportingPeriodIds text)
+CREATE OR REPLACE FUNCTION camdecmps.rpt_em_emission_view_summary
+(
+    monitorplanid text, 
+    locationid text, 
+    reportingperiodids text
+)
     RETURNS TABLE
     (
-        period_description varchar,
+        period_description character varying,
         op_hours numeric,
         op_time numeric,
         heat_input numeric,
@@ -16,58 +18,107 @@ CREATE OR REPLACE FUNCTION camdecmps.rpt_em_emission_view_summary(
         co2_mass numeric,
         nox_rate numeric,
         nox_mass numeric
-    ) 
-    LANGUAGE 'plpgsql'
-    COST 100
-    VOLATILE PARALLEL UNSAFE
-    ROWS 1000
-
-AS $BODY$
-
+    )
+LANGUAGE plpgsql
+AS $function$
 BEGIN
-
-RETURN QUERY
-  select  lst.period_description,
-			max( case when lst.parameter_cd = 'OPHOURS' then lst.summary_value end ) as op_hours,
-			max( case when lst.parameter_cd = 'OPTIME' then lst.summary_value end ) as op_time,
-			max( case when lst.parameter_cd = 'HIT' then lst.summary_value end ) as heat_input,
-			max( case when lst.parameter_cd = 'SO2M' then lst.summary_value end ) as so2_mass,
-			max( case when lst.parameter_cd = 'CO2M' then lst.summary_value end ) as co2_mass,
-			max( case when lst.parameter_cd = 'NOXR' then lst.summary_value end ) as nox_rate,
-			max( case when lst.parameter_cd = 'NOXM' then lst.summary_value end ) as nox_mass
-  from  ( select mpl.mon_plan_id, smv.mon_loc_id,smv.rpt_period_id,prs.period_description,
-           smv.parameter_cd, typ.summary_num,typ.summary_type_cd,typ.summary_name,
-                    case ( typ.summary_type_cd )
-                        when 'QTRRPT'   THEN smv.current_rpt_period_total
-                        when 'QTRCALC'  THEN smv.calc_current_rpt_period_total
-                        when 'YEARRPT'  THEN smv.year_total
-                        when 'YEARCALC' THEN smv.calc_year_total
-                        when 'OSRPT'    THEN smv.os_total
-                        when 'OSCALC'   THEN smv.calc_os_total
-                    end as summary_value
- 	   from camdecmps.SUMMARY_VALUE smv
-	   join camdecmps.MONITOR_PLAN_LOCATION mpl on mpl.mon_loc_id=smv.mon_loc_id
-		   and mpl.mon_plan_id = monitorPlanId
-		   and smv.parameter_cd in ('CO2M','HIT','NOXM','NOXR','OPHOURS','OPTIME','SO2M') 
-		   and smv.mon_loc_id = locationId
-  	   join camdecmps.EMISSION_EVALUATION ems  on ems.rpt_period_id =smv.rpt_period_id
-           and mpl.mon_plan_id=ems.mon_plan_id 
-	       and smv.rpt_period_id = any( string_to_array( reportingPeriodIds, ',' )::numeric[] )
- 	   join camdecmpsmd.REPORTING_PERIOD prs on prs.rpt_period_id = ems.rpt_period_id
-  	   join (
-			 select 'QTRRPT' as summary_type_cd, 'Quarterly Reported' as summary_name, 1 as summary_num union all
-         	 select 'QTRCALC' as summary_type_cd, 'Quarterly Calculated' as summary_name, 2 as summary_num union all
-        	 select 'YEARRPT' as summary_type_cd, 'Year to Date Reported' as summary_name, 3 as summary_num union all
-         	 select 'YEARCALC' as summary_type_cd, 'Year to Date Calculated' as summary_name, 4 as summary_num union all
-         	 select 'OSRPT' as summary_type_cd, 'Ozone Season Reported' as summary_name, 5 as summary_num union all
-         	 select 'OSCALC' as summary_type_cd, 'Ozone Season Calculated' as summary_name, 6 as summary_num
-             ) typ
-           on null is null
-          ) lst   
-      group by lst.mon_loc_id, lst.rpt_period_id,lst.period_description,lst.summary_num,lst.summary_type_cd,lst.summary_name
-      order by period_description, summary_num;
-				
+    
+    RETURN QUERY
+        select  cmb.period_description, 
+                cmb.op_hours,
+                cmb.op_time,
+                cmb.heat_input,
+                cmb.so2_mass,
+                cmb.co2_mass,
+                cmb.nox_rate,
+                cmb.nox_mass
+          from  (
+                    select  lst.calendar_year,
+                            lst.period_description, 
+                            lst.summary_name as row_name,
+                            max( case when lst.parameter_cd = 'OPHOURS' then lst.summary_value end ) as op_hours,
+                            max( case when lst.parameter_cd = 'OPTIME' then lst.summary_value end ) as op_time,
+                            max( case when lst.parameter_cd = 'HIT' then lst.summary_value end ) as heat_input,
+                            max( case when lst.parameter_cd = 'SO2M' then lst.summary_value end ) as so2_mass,
+                            max( case when lst.parameter_cd = 'CO2M' then lst.summary_value end ) as co2_mass,
+                            max( case when lst.parameter_cd = 'NOXR' then lst.summary_value end ) as nox_rate,
+                            max( case when lst.parameter_cd = 'NOXM' then lst.summary_value end ) as nox_mass,
+                            lst.summary_num
+                      from  (
+                                select  smv.mon_loc_id,
+                                        smv.rpt_period_id,
+                                        prd.calendar_year,
+                                        case ( typ.summary_type_cd )
+                                            when 'QTRRPT'   THEN prd.period_description
+                                            when 'OSRPT'    THEN prd.calendar_year || ' Ozone Season'
+                                            when 'YEARRPT'  THEN prd.calendar_year || ' Year-to-Date'
+                                        end as period_description,
+                                        smv.parameter_cd,
+                                        typ.summary_num,   
+                                        typ.summary_type_cd,
+                                        typ.summary_name,
+                                        case ( typ.summary_type_cd )
+                                            when 'QTRRPT'   THEN smv.current_rpt_period_total
+                                            when 'YEARRPT'  THEN smv.year_total
+                                            when 'OSRPT'    THEN smv.os_total
+                                        end as summary_value
+                                  from  (
+                                            select  sel.mon_plan_id,
+                                                    sel.mon_loc_id,
+                                                    (
+                                                        select  sub.rpt_period_id
+                                                          from  camdecmpsmd.REPORTING_PERIOD sub
+                                                         where  sub.calendar_year = prd.calendar_year
+                                                           and  sub.quarter = max( prd.quarter )
+                                                    ) as rpt_period_id
+                                              from  (
+                                                        select  monitorplanid as mon_plan_id,
+                                                                reportingperiodids as rpt_period_id_list,
+                                                                locationid as mon_loc_id
+                                                    ) sel
+                                                    join camdecmpsmd.REPORTING_PERIOD prd
+                                                      on prd.rpt_period_id in ( select unnest( string_to_array( sel.rpt_period_id_list, ',' )::numeric[] ) )
+                                             group
+                                                by  sel.mon_plan_id,
+                                                    sel.mon_loc_id,
+                                                    prd.calendar_year
+                                        ) sel
+                                        join camdecmps.EMISSION_EVALUATION ems using ( mon_plan_id, rpt_period_id )
+                                        join camdecmpsmd.REPORTING_PERIOD prs using ( rpt_period_id )
+                                        join camdecmpsmd.REPORTING_PERIOD prd
+                                          on prd.calendar_year = prs.calendar_year
+                                         and prd.quarter <= prs.quarter
+                                        join camdecmps.MONITOR_PLAN_LOCATION mpl using ( mon_plan_id, mon_loc_id )
+                                        join camdecmps.SUMMARY_VALUE smv
+                                          on smv.rpt_period_id = prd.rpt_period_id
+                                         and smv.mon_loc_id = mpl.mon_loc_id
+                                         and smv.parameter_cd in ( 'CO2M', 'HIT', 'NOXM', 'NOXR', 'OPHOURS', 'OPTIME', 'SO2M' )
+                                        join (
+                                                select 'QTRRPT' as summary_type_cd, 'Quarterly Reported' as summary_name, 1 as summary_num union all
+                                                select 'OSRPT' as summary_type_cd, 'Ozone Season Reported' as summary_name, 2 as summary_num union all
+                                                select 'YEARRPT' as summary_type_cd, 'Year to Date Reported' as summary_name, 3 as summary_num
+                                             ) typ
+                                          on null is null
+                                 where  (
+                                            typ.summary_type_cd = 'QTRRPT'
+                                            or
+                                            prd.rpt_period_id = sel.rpt_period_id
+                                        )
+                            ) lst
+                     group
+                        by  lst.mon_loc_id,
+                            lst.rpt_period_id,
+                            lst.calendar_year,
+                            lst.period_description,
+                            lst.summary_num,   
+                            lst.summary_type_cd,
+                            lst.summary_name
+                ) cmb
+         order
+            by  calendar_year,
+                summary_num,
+                period_description;
+    
 END;
-$BODY$;
-
-
+$function$
+;

--- a/camdecmpswks/functions/rpt_em_emission_view_summary.sql
+++ b/camdecmpswks/functions/rpt_em_emission_view_summary.sql
@@ -2,13 +2,15 @@
 
 -- DROP FUNCTION IF EXISTS camdecmpswks.rpt_em_emission_view_summary(text, text, text);
 
-CREATE OR REPLACE FUNCTION camdecmpswks.rpt_em_emission_view_summary(
-	monitorPlanId text,
-	locationId text,
-	reportingPeriodIds text)
-    RETURNS TABLE 
+CREATE OR REPLACE FUNCTION camdecmpswks.rpt_em_emission_view_summary
+(
+    monitorplanid text, 
+    locationid text, 
+    reportingperiodids text
+)
+    RETURNS TABLE
     (
-        period_description varchar,
+        period_description character varying,
         op_hours numeric,
         op_time numeric,
         heat_input numeric,
@@ -16,108 +18,195 @@ CREATE OR REPLACE FUNCTION camdecmpswks.rpt_em_emission_view_summary(
         co2_mass numeric,
         nox_rate numeric,
         nox_mass numeric
-    ) 
-    LANGUAGE 'plpgsql'
-    COST 100
-    VOLATILE PARALLEL UNSAFE
-    ROWS 1000
-
-AS $BODY$
-
+    )
+LANGUAGE plpgsql
+AS $function$
 BEGIN
-  /* get data for target quarter. It's not the same version as in official(camdecmps)
-    This Workspace version will get data from both the camdecmps amd camdecmpswks SUMMARY_VALUE 
-	tables. if the camdecmpswks.EMISSION_EVALUATION row exists for the MON_PLAN_ID and target quarter RPT_PERIOD_ID, then 
-	the data will come from the Workspace (camdecmpswks) SUMMAYR_VALUE table, otherwise the data will come from the 
-	Official (camdecmps) SUMMARY_VALUE table.
-  */
-  RETURN QUERY
-  select  cmb.period_description, cmb.op_hours, cmb.op_time,
-	      cmb.heat_input, cmb.so2_mass, cmb.co2_mass, cmb.nox_rate, cmb.nox_mass
-  from (select lst.period_description, lst.summary_name as row_name,
-			max( case when lst.parameter_cd = 'OPHOURS' then lst.summary_value end ) as op_hours,
-			max( case when lst.parameter_cd = 'OPTIME' then lst.summary_value end ) as op_time,
-			max( case when lst.parameter_cd = 'HIT' then lst.summary_value end ) as heat_input,
-			max( case when lst.parameter_cd = 'SO2M' then lst.summary_value end ) as so2_mass,
-			max( case when lst.parameter_cd = 'CO2M' then lst.summary_value end ) as co2_mass,
-			max( case when lst.parameter_cd = 'NOXR' then lst.summary_value end ) as nox_rate,
-			max( case when lst.parameter_cd = 'NOXM' then lst.summary_value end ) as nox_mass,
-			lst.summary_num
-        from (select smv.mon_loc_id,smv.rpt_period_id,prs.period_description,
-              smv.parameter_cd, typ.summary_num,typ.summary_type_cd,typ.summary_name,
-                    case ( typ.summary_type_cd )
-                        when 'QTRRPT'   THEN smv.current_rpt_period_total
-                        when 'QTRCALC'  THEN smv.calc_current_rpt_period_total
-                        when 'YEARRPT'  THEN smv.year_total
-                        when 'YEARCALC' THEN smv.calc_year_total
-                        when 'OSRPT'    THEN smv.os_total
-                        when 'OSCALC'   THEN smv.calc_os_total
-                    end as summary_value
-		     from  camdecmps.SUMMARY_VALUE smv
-		      join camdecmps.MONITOR_PLAN_LOCATION mpl on mpl.mon_loc_id=smv.mon_loc_id
-					and mpl.mon_plan_id = monitorPlanId
-					and smv.parameter_cd in ('CO2M','HIT','NOXM','NOXR','OPHOURS','OPTIME','SO2M') 
-					and smv.mon_loc_id = locationId
-  	          join camdecmps.EMISSION_EVALUATION ems on ems.rpt_period_id =smv.rpt_period_id
-					and mpl.mon_plan_id=ems.mon_plan_id 
-					and smv.rpt_period_id = any( string_to_array( reportingPeriodIds, ',' )::numeric[] )
-		      join camdecmpsmd.REPORTING_PERIOD prs on prs.rpt_period_id = ems.rpt_period_id
-  		      join( 
-			     select 'QTRRPT' as summary_type_cd, 'Quarterly Reported' as summary_name, 1 as summary_num union all
-        		 select 'QTRCALC' as summary_type_cd, 'Quarterly Calculated' as summary_name, 2 as summary_num union all
-        		 select 'YEARRPT' as summary_type_cd, 'Year to Date Reported' as summary_name, 3 as summary_num union all
-         		 select 'YEARCALC' as summary_type_cd, 'Year to Date Calculated' as summary_name, 4 as summary_num union all
-        		 select 'OSRPT' as summary_type_cd, 'Ozone Season Reported' as summary_name, 5 as summary_num union all
-         		 select 'OSCALC' as summary_type_cd, 'Ozone Season Calculated' as summary_name, 6 as summary_num
-                  ) typ
-				on null is null
-            where not exists
-				(select 1 from  camdecmpswks.EMISSION_EVALUATION exs
-					where exs.rpt_period_id = prs.rpt_period_id 
-					and exs.mon_plan_id = mpl.mon_plan_id)
-				) lst   
-			group by  lst.mon_loc_id, lst.rpt_period_id,lst.period_description, lst.summary_num,lst.summary_type_cd,lst.summary_name
-    union  all
-        select  lst.period_description, lst.summary_name as row_name,
-            max( case when lst.parameter_cd = 'OPHOURS' then lst.summary_value end ) as op_hours,
-            max( case when lst.parameter_cd = 'OPTIME' then lst.summary_value end ) as op_time,
-            max( case when lst.parameter_cd = 'HIT' then lst.summary_value end ) as heat_input,
-            max( case when lst.parameter_cd = 'SO2M' then lst.summary_value end ) as so2_mass,
-			max( case when lst.parameter_cd = 'CO2M' then lst.summary_value end ) as co2_mass,
-			max( case when lst.parameter_cd = 'NOXR' then lst.summary_value end ) as nox_rate,
-			max( case when lst.parameter_cd = 'NOXM' then lst.summary_value end ) as nox_mass,
-             lst.summary_num
-        from (select smv.mon_loc_id,smv.rpt_period_id,prs.period_description,
-                 smv.parameter_cd, typ.summary_num,typ.summary_type_cd,typ.summary_name,
-                     case ( typ.summary_type_cd )
-                         when 'QTRRPT'   THEN smv.current_rpt_period_total
-                         when 'QTRCALC'  THEN smv.calc_current_rpt_period_total
-                         when 'YEARRPT'  THEN smv.year_total
-                         when 'YEARCALC' THEN smv.calc_year_total
-                         when 'OSRPT'    THEN smv.os_total
-                         when 'OSCALC'   THEN smv.calc_os_total
-                      end as summary_value
-			    from  camdecmpswks.SUMMARY_VALUE smv
-				 join camdecmpswks.MONITOR_PLAN_LOCATION mpl on mpl.mon_loc_id=smv.mon_loc_id
-						and mpl.mon_plan_id = monitorPlanId
-						and smv.parameter_cd in ('CO2M','HIT','NOXM','NOXR','OPHOURS','OPTIME','SO2M') 
-						and smv.mon_loc_id = locationId
-  	    	     join camdecmpswks.EMISSION_EVALUATION ems on ems.rpt_period_id =smv.rpt_period_id
-						and mpl.mon_plan_id=ems.mon_plan_id 
-						and smv.rpt_period_id = any( string_to_array( reportingPeriodIds, ',' )::numeric[] )
-			     join camdecmpsmd.REPORTING_PERIOD prs on prs.rpt_period_id = smv.rpt_period_id
-				 join (
-				     select 'QTRRPT' as summary_type_cd, 'Quarterly Reported' as summary_name, 1 as summary_num union all
-            		 select 'QTRCALC' as summary_type_cd, 'Quarterly Calculated' as summary_name, 2 as summary_num union all
-            		 select 'YEARRPT' as summary_type_cd, 'Year to Date Reported' as summary_name, 3 as summary_num union all
-            		 select 'YEARCALC' as summary_type_cd, 'Year to Date Calculated' as summary_name, 4 as summary_num union all
-            		 select 'OSRPT' as summary_type_cd, 'Ozone Season Reported' as summary_name, 5 as summary_num union all
-            		 select 'OSCALC' as summary_type_cd, 'Ozone Season Calculated' as summary_name, 6 as summary_num
-                    ) typ
-                  on null is null			
-         	   ) lst
-         group by lst.mon_loc_id, lst.rpt_period_id,lst.period_description,lst.summary_num, lst.summary_type_cd, lst.summary_name
-        ) cmb
-   order  by  period_description, summary_num;
+    
+    RETURN QUERY
+        select  cmb.period_description, 
+                cmb.op_hours,
+                cmb.op_time,
+                cmb.heat_input,
+                cmb.so2_mass,
+                cmb.co2_mass,
+                cmb.nox_rate,
+                cmb.nox_mass
+          from  (
+                    select  lst.calendar_year,
+                            lst.period_description, 
+                            lst.summary_name as row_name,
+                            max( case when lst.parameter_cd = 'OPHOURS' then lst.summary_value end ) as op_hours,
+                            max( case when lst.parameter_cd = 'OPTIME' then lst.summary_value end ) as op_time,
+                            max( case when lst.parameter_cd = 'HIT' then lst.summary_value end ) as heat_input,
+                            max( case when lst.parameter_cd = 'SO2M' then lst.summary_value end ) as so2_mass,
+                            max( case when lst.parameter_cd = 'CO2M' then lst.summary_value end ) as co2_mass,
+                            max( case when lst.parameter_cd = 'NOXR' then lst.summary_value end ) as nox_rate,
+                            max( case when lst.parameter_cd = 'NOXM' then lst.summary_value end ) as nox_mass,
+                            lst.summary_num
+                      from  (
+                                select  smv.mon_loc_id,
+                                        smv.rpt_period_id,
+                                        prd.calendar_year,
+                                        case ( typ.summary_type_cd )
+                                            when 'QTRRPT'   THEN prd.period_description
+                                            when 'OSRPT'    THEN prd.calendar_year || ' Ozone Season'
+                                            when 'YEARRPT'  THEN prd.calendar_year || ' Year-to-Date'
+                                        end as period_description,
+                                        smv.parameter_cd,
+                                        typ.summary_num,   
+                                        typ.summary_type_cd,
+                                        typ.summary_name,
+                                        case ( typ.summary_type_cd )
+                                            when 'QTRRPT'   THEN smv.current_rpt_period_total
+                                            when 'YEARRPT'  THEN smv.year_total
+                                            when 'OSRPT'    THEN smv.os_total
+                                        end as summary_value
+                                  from  (
+                                            select  sel.mon_plan_id,
+                                                    sel.mon_loc_id,
+                                                    (
+                                                        select  sub.rpt_period_id
+                                                          from  camdecmpsmd.REPORTING_PERIOD sub
+                                                         where  sub.calendar_year = prd.calendar_year
+                                                           and  sub.quarter = max( prd.quarter )
+                                                    ) as rpt_period_id
+                                              from  (
+                                                        select  monitorplanid as mon_plan_id,
+                                                                reportingperiodids as rpt_period_id_list,
+                                                                locationid as mon_loc_id
+                                                    ) sel
+                                                    join camdecmpsmd.REPORTING_PERIOD prd
+                                                      on prd.rpt_period_id in ( select unnest( string_to_array( sel.rpt_period_id_list, ',' )::numeric[] ) )
+                                             group
+                                                by  sel.mon_plan_id,
+                                                    sel.mon_loc_id,
+                                                    prd.calendar_year
+                                        ) sel
+                                        join camdecmps.EMISSION_EVALUATION ems using ( mon_plan_id, rpt_period_id )
+                                        join camdecmpsmd.REPORTING_PERIOD prs using ( rpt_period_id )
+                                        join camdecmpsmd.REPORTING_PERIOD prd
+                                          on prd.calendar_year = prs.calendar_year
+                                         and prd.quarter <= prs.quarter
+                                        join camdecmps.MONITOR_PLAN_LOCATION mpl using ( mon_plan_id, mon_loc_id )
+                                        join camdecmps.SUMMARY_VALUE smv
+                                          on smv.rpt_period_id = prd.rpt_period_id
+                                         and smv.mon_loc_id = mpl.mon_loc_id
+                                         and smv.parameter_cd in ( 'CO2M', 'HIT', 'NOXM', 'NOXR', 'OPHOURS', 'OPTIME', 'SO2M' )
+                                        join (
+                                                select 'QTRRPT' as summary_type_cd, 'Quarterly Reported' as summary_name, 1 as summary_num union all
+                                                select 'OSRPT' as summary_type_cd, 'Ozone Season Reported' as summary_name, 2 as summary_num union all
+                                                select 'YEARRPT' as summary_type_cd, 'Year to Date Reported' as summary_name, 3 as summary_num
+                                             ) typ
+                                          on null is null
+                                 where  (
+                                            typ.summary_type_cd = 'QTRRPT'
+                                            or
+                                            prd.rpt_period_id = sel.rpt_period_id
+                                        )
+                                   and  not exists
+                                        (
+                                            select  1
+                                              from  camdecmpswks.EMISSION_EVALUATION exs
+                                             where  exs.rpt_period_id = prd.rpt_period_id -- uses prd instead of sel to include all quarters involved
+                                               and  exs.mon_plan_id = sel.mon_plan_id
+                                        )
+                            ) lst
+                     group
+                        by  lst.mon_loc_id,
+                            lst.rpt_period_id,
+                            lst.calendar_year,
+                            lst.period_description,
+                            lst.summary_num,   
+                            lst.summary_type_cd,
+                            lst.summary_name
+                    union   all
+                    select  lst.calendar_year,
+                            lst.period_description, 
+                            lst.summary_name as row_name,
+                            max( case when lst.parameter_cd = 'OPHOURS' then lst.summary_value end ) as op_hours,
+                            max( case when lst.parameter_cd = 'OPTIME' then lst.summary_value end ) as op_time,
+                            max( case when lst.parameter_cd = 'HIT' then lst.summary_value end ) as heat_input,
+                            max( case when lst.parameter_cd = 'SO2M' then lst.summary_value end ) as so2_mass,
+                            max( case when lst.parameter_cd = 'CO2M' then lst.summary_value end ) as co2_mass,
+                            max( case when lst.parameter_cd = 'NOXR' then lst.summary_value end ) as nox_rate,
+                            max( case when lst.parameter_cd = 'NOXM' then lst.summary_value end ) as nox_mass,
+                            lst.summary_num
+                      from  (
+                                select  smv.mon_loc_id,
+                                        smv.rpt_period_id,
+                                        prd.calendar_year,
+                                        case ( typ.summary_type_cd )
+                                            when 'QTRRPT'   THEN prd.period_description
+                                            when 'OSRPT'    THEN prd.calendar_year || ' Ozone Season'
+                                            when 'YEARRPT'  THEN prd.calendar_year || ' Year-to-Date'
+                                        end as period_description,
+                                        smv.parameter_cd,
+                                        typ.summary_num,   
+                                        typ.summary_type_cd,
+                                        typ.summary_name,
+                                        case ( typ.summary_type_cd )
+                                            when 'QTRRPT'   THEN smv.current_rpt_period_total
+                                            when 'YEARRPT'  THEN smv.year_total
+                                            when 'OSRPT'    THEN smv.os_total
+                                        end as summary_value
+                                  from  (
+                                            select  sel.mon_plan_id,
+                                                    sel.mon_loc_id,
+                                                    (
+                                                        select  sub.rpt_period_id
+                                                          from  camdecmpsmd.REPORTING_PERIOD sub
+                                                         where  sub.calendar_year = prd.calendar_year
+                                                           and  sub.quarter = max( prd.quarter )
+                                                    ) as rpt_period_id
+                                              from  (
+                                                        select  monitorplanid as mon_plan_id,
+                                                                reportingperiodids as rpt_period_id_list,
+                                                                locationid as mon_loc_id
+                                                    ) sel
+                                                    join camdecmpsmd.REPORTING_PERIOD prd
+                                                      on prd.rpt_period_id in ( select unnest( string_to_array( sel.rpt_period_id_list, ',' )::numeric[] ) )
+                                             group
+                                                by  sel.mon_plan_id,
+                                                    sel.mon_loc_id,
+                                                    prd.calendar_year
+                                        ) sel
+                                        join camdecmpswks.EMISSION_EVALUATION ems using ( mon_plan_id, rpt_period_id )
+                                        join camdecmpsmd.REPORTING_PERIOD prs using ( rpt_period_id )
+                                        join camdecmpsmd.REPORTING_PERIOD prd
+                                          on prd.calendar_year = prs.calendar_year
+                                         and prd.quarter <= prs.quarter
+                                        join camdecmpswks.MONITOR_PLAN_LOCATION mpl using ( mon_plan_id, mon_loc_id )
+                                        join camdecmpswks.SUMMARY_VALUE smv
+                                          on smv.rpt_period_id = prd.rpt_period_id
+                                         and smv.mon_loc_id = mpl.mon_loc_id
+                                         and smv.parameter_cd in ( 'CO2M', 'HIT', 'NOXM', 'NOXR', 'OPHOURS', 'OPTIME', 'SO2M' )
+                                        join (
+                                                select 'QTRRPT' as summary_type_cd, 'Quarterly Reported' as summary_name, 1 as summary_num union all
+                                                select 'OSRPT' as summary_type_cd, 'Ozone Season Reported' as summary_name, 2 as summary_num union all
+                                                select 'YEARRPT' as summary_type_cd, 'Year to Date Reported' as summary_name, 3 as summary_num
+                                             ) typ
+                                          on null is null
+                                 where  (
+                                            typ.summary_type_cd = 'QTRRPT'
+                                            or
+                                            prd.rpt_period_id = sel.rpt_period_id
+                                        )
+                            ) lst
+                     group
+                        by  lst.mon_loc_id,
+                            lst.rpt_period_id,
+                            lst.calendar_year,
+                            lst.period_description,
+                            lst.summary_num,   
+                            lst.summary_type_cd,
+                            lst.summary_name
+                ) cmb
+         order
+            by  calendar_year,
+                summary_num,
+                period_description;
+    
 END;
-$BODY$;
+$function$
+;

--- a/deployments/ecmps/release-v2.0-fix/Sprint28/6666/camdecmps.rpt_em_emission_view_summary.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint28/6666/camdecmps.rpt_em_emission_view_summary.sql
@@ -2,13 +2,15 @@
 
 -- DROP FUNCTION IF EXISTS camdecmps.rpt_em_emission_view_summary(text, text, text);
 
-CREATE OR REPLACE FUNCTION camdecmps.rpt_em_emission_view_summary(
-	monitorPlanId text,
-	locationId text,
-	reportingPeriodIds text)
+CREATE OR REPLACE FUNCTION camdecmps.rpt_em_emission_view_summary
+(
+    monitorplanid text, 
+    locationid text, 
+    reportingperiodids text
+)
     RETURNS TABLE
     (
-        period_description varchar,
+        period_description character varying,
         op_hours numeric,
         op_time numeric,
         heat_input numeric,
@@ -16,58 +18,107 @@ CREATE OR REPLACE FUNCTION camdecmps.rpt_em_emission_view_summary(
         co2_mass numeric,
         nox_rate numeric,
         nox_mass numeric
-    ) 
-    LANGUAGE 'plpgsql'
-    COST 100
-    VOLATILE PARALLEL UNSAFE
-    ROWS 1000
-
-AS $BODY$
-
+    )
+LANGUAGE plpgsql
+AS $function$
 BEGIN
-
-RETURN QUERY
-  select  lst.period_description,
-			max( case when lst.parameter_cd = 'OPHOURS' then lst.summary_value end ) as op_hours,
-			max( case when lst.parameter_cd = 'OPTIME' then lst.summary_value end ) as op_time,
-			max( case when lst.parameter_cd = 'HIT' then lst.summary_value end ) as heat_input,
-			max( case when lst.parameter_cd = 'SO2M' then lst.summary_value end ) as so2_mass,
-			max( case when lst.parameter_cd = 'CO2M' then lst.summary_value end ) as co2_mass,
-			max( case when lst.parameter_cd = 'NOXR' then lst.summary_value end ) as nox_rate,
-			max( case when lst.parameter_cd = 'NOXM' then lst.summary_value end ) as nox_mass
-  from  ( select mpl.mon_plan_id, smv.mon_loc_id,smv.rpt_period_id,prs.period_description,
-           smv.parameter_cd, typ.summary_num,typ.summary_type_cd,typ.summary_name,
-                    case ( typ.summary_type_cd )
-                        when 'QTRRPT'   THEN smv.current_rpt_period_total
-                        when 'QTRCALC'  THEN smv.calc_current_rpt_period_total
-                        when 'YEARRPT'  THEN smv.year_total
-                        when 'YEARCALC' THEN smv.calc_year_total
-                        when 'OSRPT'    THEN smv.os_total
-                        when 'OSCALC'   THEN smv.calc_os_total
-                    end as summary_value
- 	   from camdecmps.SUMMARY_VALUE smv
-	   join camdecmps.MONITOR_PLAN_LOCATION mpl on mpl.mon_loc_id=smv.mon_loc_id
-		   and mpl.mon_plan_id = monitorPlanId
-		   and smv.parameter_cd in ('CO2M','HIT','NOXM','NOXR','OPHOURS','OPTIME','SO2M') 
-		   and smv.mon_loc_id = locationId
-  	   join camdecmps.EMISSION_EVALUATION ems  on ems.rpt_period_id =smv.rpt_period_id
-           and mpl.mon_plan_id=ems.mon_plan_id 
-	       and smv.rpt_period_id = any( string_to_array( reportingPeriodIds, ',' )::numeric[] )
- 	   join camdecmpsmd.REPORTING_PERIOD prs on prs.rpt_period_id = ems.rpt_period_id
-  	   join (
-			 select 'QTRRPT' as summary_type_cd, 'Quarterly Reported' as summary_name, 1 as summary_num union all
-         	 select 'QTRCALC' as summary_type_cd, 'Quarterly Calculated' as summary_name, 2 as summary_num union all
-        	 select 'YEARRPT' as summary_type_cd, 'Year to Date Reported' as summary_name, 3 as summary_num union all
-         	 select 'YEARCALC' as summary_type_cd, 'Year to Date Calculated' as summary_name, 4 as summary_num union all
-         	 select 'OSRPT' as summary_type_cd, 'Ozone Season Reported' as summary_name, 5 as summary_num union all
-         	 select 'OSCALC' as summary_type_cd, 'Ozone Season Calculated' as summary_name, 6 as summary_num
-             ) typ
-           on null is null
-          ) lst   
-      group by lst.mon_loc_id, lst.rpt_period_id,lst.period_description,lst.summary_num,lst.summary_type_cd,lst.summary_name
-      order by period_description, summary_num;
-				
+    
+    RETURN QUERY
+        select  cmb.period_description, 
+                cmb.op_hours,
+                cmb.op_time,
+                cmb.heat_input,
+                cmb.so2_mass,
+                cmb.co2_mass,
+                cmb.nox_rate,
+                cmb.nox_mass
+          from  (
+                    select  lst.calendar_year,
+                            lst.period_description, 
+                            lst.summary_name as row_name,
+                            max( case when lst.parameter_cd = 'OPHOURS' then lst.summary_value end ) as op_hours,
+                            max( case when lst.parameter_cd = 'OPTIME' then lst.summary_value end ) as op_time,
+                            max( case when lst.parameter_cd = 'HIT' then lst.summary_value end ) as heat_input,
+                            max( case when lst.parameter_cd = 'SO2M' then lst.summary_value end ) as so2_mass,
+                            max( case when lst.parameter_cd = 'CO2M' then lst.summary_value end ) as co2_mass,
+                            max( case when lst.parameter_cd = 'NOXR' then lst.summary_value end ) as nox_rate,
+                            max( case when lst.parameter_cd = 'NOXM' then lst.summary_value end ) as nox_mass,
+                            lst.summary_num
+                      from  (
+                                select  smv.mon_loc_id,
+                                        smv.rpt_period_id,
+                                        prd.calendar_year,
+                                        case ( typ.summary_type_cd )
+                                            when 'QTRRPT'   THEN prd.period_description
+                                            when 'OSRPT'    THEN prd.calendar_year || ' Ozone Season'
+                                            when 'YEARRPT'  THEN prd.calendar_year || ' Year-to-Date'
+                                        end as period_description,
+                                        smv.parameter_cd,
+                                        typ.summary_num,   
+                                        typ.summary_type_cd,
+                                        typ.summary_name,
+                                        case ( typ.summary_type_cd )
+                                            when 'QTRRPT'   THEN smv.current_rpt_period_total
+                                            when 'YEARRPT'  THEN smv.year_total
+                                            when 'OSRPT'    THEN smv.os_total
+                                        end as summary_value
+                                  from  (
+                                            select  sel.mon_plan_id,
+                                                    sel.mon_loc_id,
+                                                    (
+                                                        select  sub.rpt_period_id
+                                                          from  camdecmpsmd.REPORTING_PERIOD sub
+                                                         where  sub.calendar_year = prd.calendar_year
+                                                           and  sub.quarter = max( prd.quarter )
+                                                    ) as rpt_period_id
+                                              from  (
+                                                        select  monitorplanid as mon_plan_id,
+                                                                reportingperiodids as rpt_period_id_list,
+                                                                locationid as mon_loc_id
+                                                    ) sel
+                                                    join camdecmpsmd.REPORTING_PERIOD prd
+                                                      on prd.rpt_period_id in ( select unnest( string_to_array( sel.rpt_period_id_list, ',' )::numeric[] ) )
+                                             group
+                                                by  sel.mon_plan_id,
+                                                    sel.mon_loc_id,
+                                                    prd.calendar_year
+                                        ) sel
+                                        join camdecmps.EMISSION_EVALUATION ems using ( mon_plan_id, rpt_period_id )
+                                        join camdecmpsmd.REPORTING_PERIOD prs using ( rpt_period_id )
+                                        join camdecmpsmd.REPORTING_PERIOD prd
+                                          on prd.calendar_year = prs.calendar_year
+                                         and prd.quarter <= prs.quarter
+                                        join camdecmps.MONITOR_PLAN_LOCATION mpl using ( mon_plan_id, mon_loc_id )
+                                        join camdecmps.SUMMARY_VALUE smv
+                                          on smv.rpt_period_id = prd.rpt_period_id
+                                         and smv.mon_loc_id = mpl.mon_loc_id
+                                         and smv.parameter_cd in ( 'CO2M', 'HIT', 'NOXM', 'NOXR', 'OPHOURS', 'OPTIME', 'SO2M' )
+                                        join (
+                                                select 'QTRRPT' as summary_type_cd, 'Quarterly Reported' as summary_name, 1 as summary_num union all
+                                                select 'OSRPT' as summary_type_cd, 'Ozone Season Reported' as summary_name, 2 as summary_num union all
+                                                select 'YEARRPT' as summary_type_cd, 'Year to Date Reported' as summary_name, 3 as summary_num
+                                             ) typ
+                                          on null is null
+                                 where  (
+                                            typ.summary_type_cd = 'QTRRPT'
+                                            or
+                                            prd.rpt_period_id = sel.rpt_period_id
+                                        )
+                            ) lst
+                     group
+                        by  lst.mon_loc_id,
+                            lst.rpt_period_id,
+                            lst.calendar_year,
+                            lst.period_description,
+                            lst.summary_num,   
+                            lst.summary_type_cd,
+                            lst.summary_name
+                ) cmb
+         order
+            by  calendar_year,
+                summary_num,
+                period_description;
+    
 END;
-$BODY$;
-
-
+$function$
+;

--- a/deployments/ecmps/release-v2.0-fix/Sprint28/6666/camdecmpswks.rpt_em_emission_view_summary.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint28/6666/camdecmpswks.rpt_em_emission_view_summary.sql
@@ -2,13 +2,15 @@
 
 -- DROP FUNCTION IF EXISTS camdecmpswks.rpt_em_emission_view_summary(text, text, text);
 
-CREATE OR REPLACE FUNCTION camdecmpswks.rpt_em_emission_view_summary(
-	monitorPlanId text,
-	locationId text,
-	reportingPeriodIds text)
-    RETURNS TABLE 
+CREATE OR REPLACE FUNCTION camdecmpswks.rpt_em_emission_view_summary
+(
+    monitorplanid text, 
+    locationid text, 
+    reportingperiodids text
+)
+    RETURNS TABLE
     (
-        period_description varchar,
+        period_description character varying,
         op_hours numeric,
         op_time numeric,
         heat_input numeric,
@@ -16,108 +18,195 @@ CREATE OR REPLACE FUNCTION camdecmpswks.rpt_em_emission_view_summary(
         co2_mass numeric,
         nox_rate numeric,
         nox_mass numeric
-    ) 
-    LANGUAGE 'plpgsql'
-    COST 100
-    VOLATILE PARALLEL UNSAFE
-    ROWS 1000
-
-AS $BODY$
-
+    )
+LANGUAGE plpgsql
+AS $function$
 BEGIN
-  /* get data for target quarter. It's not the same version as in official(camdecmps)
-    This Workspace version will get data from both the camdecmps amd camdecmpswks SUMMARY_VALUE 
-	tables. if the camdecmpswks.EMISSION_EVALUATION row exists for the MON_PLAN_ID and target quarter RPT_PERIOD_ID, then 
-	the data will come from the Workspace (camdecmpswks) SUMMAYR_VALUE table, otherwise the data will come from the 
-	Official (camdecmps) SUMMARY_VALUE table.
-  */
-  RETURN QUERY
-  select  cmb.period_description, cmb.op_hours, cmb.op_time,
-	      cmb.heat_input, cmb.so2_mass, cmb.co2_mass, cmb.nox_rate, cmb.nox_mass
-  from (select lst.period_description, lst.summary_name as row_name,
-			max( case when lst.parameter_cd = 'OPHOURS' then lst.summary_value end ) as op_hours,
-			max( case when lst.parameter_cd = 'OPTIME' then lst.summary_value end ) as op_time,
-			max( case when lst.parameter_cd = 'HIT' then lst.summary_value end ) as heat_input,
-			max( case when lst.parameter_cd = 'SO2M' then lst.summary_value end ) as so2_mass,
-			max( case when lst.parameter_cd = 'CO2M' then lst.summary_value end ) as co2_mass,
-			max( case when lst.parameter_cd = 'NOXR' then lst.summary_value end ) as nox_rate,
-			max( case when lst.parameter_cd = 'NOXM' then lst.summary_value end ) as nox_mass,
-			lst.summary_num
-        from (select smv.mon_loc_id,smv.rpt_period_id,prs.period_description,
-              smv.parameter_cd, typ.summary_num,typ.summary_type_cd,typ.summary_name,
-                    case ( typ.summary_type_cd )
-                        when 'QTRRPT'   THEN smv.current_rpt_period_total
-                        when 'QTRCALC'  THEN smv.calc_current_rpt_period_total
-                        when 'YEARRPT'  THEN smv.year_total
-                        when 'YEARCALC' THEN smv.calc_year_total
-                        when 'OSRPT'    THEN smv.os_total
-                        when 'OSCALC'   THEN smv.calc_os_total
-                    end as summary_value
-		     from  camdecmps.SUMMARY_VALUE smv
-		      join camdecmps.MONITOR_PLAN_LOCATION mpl on mpl.mon_loc_id=smv.mon_loc_id
-					and mpl.mon_plan_id = monitorPlanId
-					and smv.parameter_cd in ('CO2M','HIT','NOXM','NOXR','OPHOURS','OPTIME','SO2M') 
-					and smv.mon_loc_id = locationId
-  	          join camdecmps.EMISSION_EVALUATION ems on ems.rpt_period_id =smv.rpt_period_id
-					and mpl.mon_plan_id=ems.mon_plan_id 
-					and smv.rpt_period_id = any( string_to_array( reportingPeriodIds, ',' )::numeric[] )
-		      join camdecmpsmd.REPORTING_PERIOD prs on prs.rpt_period_id = ems.rpt_period_id
-  		      join( 
-			     select 'QTRRPT' as summary_type_cd, 'Quarterly Reported' as summary_name, 1 as summary_num union all
-        		 select 'QTRCALC' as summary_type_cd, 'Quarterly Calculated' as summary_name, 2 as summary_num union all
-        		 select 'YEARRPT' as summary_type_cd, 'Year to Date Reported' as summary_name, 3 as summary_num union all
-         		 select 'YEARCALC' as summary_type_cd, 'Year to Date Calculated' as summary_name, 4 as summary_num union all
-        		 select 'OSRPT' as summary_type_cd, 'Ozone Season Reported' as summary_name, 5 as summary_num union all
-         		 select 'OSCALC' as summary_type_cd, 'Ozone Season Calculated' as summary_name, 6 as summary_num
-                  ) typ
-				on null is null
-            where not exists
-				(select 1 from  camdecmpswks.EMISSION_EVALUATION exs
-					where exs.rpt_period_id = prs.rpt_period_id 
-					and exs.mon_plan_id = mpl.mon_plan_id)
-				) lst   
-			group by  lst.mon_loc_id, lst.rpt_period_id,lst.period_description, lst.summary_num,lst.summary_type_cd,lst.summary_name
-    union  all
-        select  lst.period_description, lst.summary_name as row_name,
-            max( case when lst.parameter_cd = 'OPHOURS' then lst.summary_value end ) as op_hours,
-            max( case when lst.parameter_cd = 'OPTIME' then lst.summary_value end ) as op_time,
-            max( case when lst.parameter_cd = 'HIT' then lst.summary_value end ) as heat_input,
-            max( case when lst.parameter_cd = 'SO2M' then lst.summary_value end ) as so2_mass,
-			max( case when lst.parameter_cd = 'CO2M' then lst.summary_value end ) as co2_mass,
-			max( case when lst.parameter_cd = 'NOXR' then lst.summary_value end ) as nox_rate,
-			max( case when lst.parameter_cd = 'NOXM' then lst.summary_value end ) as nox_mass,
-             lst.summary_num
-        from (select smv.mon_loc_id,smv.rpt_period_id,prs.period_description,
-                 smv.parameter_cd, typ.summary_num,typ.summary_type_cd,typ.summary_name,
-                     case ( typ.summary_type_cd )
-                         when 'QTRRPT'   THEN smv.current_rpt_period_total
-                         when 'QTRCALC'  THEN smv.calc_current_rpt_period_total
-                         when 'YEARRPT'  THEN smv.year_total
-                         when 'YEARCALC' THEN smv.calc_year_total
-                         when 'OSRPT'    THEN smv.os_total
-                         when 'OSCALC'   THEN smv.calc_os_total
-                      end as summary_value
-			    from  camdecmpswks.SUMMARY_VALUE smv
-				 join camdecmpswks.MONITOR_PLAN_LOCATION mpl on mpl.mon_loc_id=smv.mon_loc_id
-						and mpl.mon_plan_id = monitorPlanId
-						and smv.parameter_cd in ('CO2M','HIT','NOXM','NOXR','OPHOURS','OPTIME','SO2M') 
-						and smv.mon_loc_id = locationId
-  	    	     join camdecmpswks.EMISSION_EVALUATION ems on ems.rpt_period_id =smv.rpt_period_id
-						and mpl.mon_plan_id=ems.mon_plan_id 
-						and smv.rpt_period_id = any( string_to_array( reportingPeriodIds, ',' )::numeric[] )
-			     join camdecmpsmd.REPORTING_PERIOD prs on prs.rpt_period_id = smv.rpt_period_id
-				 join (
-				     select 'QTRRPT' as summary_type_cd, 'Quarterly Reported' as summary_name, 1 as summary_num union all
-            		 select 'QTRCALC' as summary_type_cd, 'Quarterly Calculated' as summary_name, 2 as summary_num union all
-            		 select 'YEARRPT' as summary_type_cd, 'Year to Date Reported' as summary_name, 3 as summary_num union all
-            		 select 'YEARCALC' as summary_type_cd, 'Year to Date Calculated' as summary_name, 4 as summary_num union all
-            		 select 'OSRPT' as summary_type_cd, 'Ozone Season Reported' as summary_name, 5 as summary_num union all
-            		 select 'OSCALC' as summary_type_cd, 'Ozone Season Calculated' as summary_name, 6 as summary_num
-                    ) typ
-                  on null is null			
-         	   ) lst
-         group by lst.mon_loc_id, lst.rpt_period_id,lst.period_description,lst.summary_num, lst.summary_type_cd, lst.summary_name
-        ) cmb
-   order  by  period_description, summary_num;
+    
+    RETURN QUERY
+        select  cmb.period_description, 
+                cmb.op_hours,
+                cmb.op_time,
+                cmb.heat_input,
+                cmb.so2_mass,
+                cmb.co2_mass,
+                cmb.nox_rate,
+                cmb.nox_mass
+          from  (
+                    select  lst.calendar_year,
+                            lst.period_description, 
+                            lst.summary_name as row_name,
+                            max( case when lst.parameter_cd = 'OPHOURS' then lst.summary_value end ) as op_hours,
+                            max( case when lst.parameter_cd = 'OPTIME' then lst.summary_value end ) as op_time,
+                            max( case when lst.parameter_cd = 'HIT' then lst.summary_value end ) as heat_input,
+                            max( case when lst.parameter_cd = 'SO2M' then lst.summary_value end ) as so2_mass,
+                            max( case when lst.parameter_cd = 'CO2M' then lst.summary_value end ) as co2_mass,
+                            max( case when lst.parameter_cd = 'NOXR' then lst.summary_value end ) as nox_rate,
+                            max( case when lst.parameter_cd = 'NOXM' then lst.summary_value end ) as nox_mass,
+                            lst.summary_num
+                      from  (
+                                select  smv.mon_loc_id,
+                                        smv.rpt_period_id,
+                                        prd.calendar_year,
+                                        case ( typ.summary_type_cd )
+                                            when 'QTRRPT'   THEN prd.period_description
+                                            when 'OSRPT'    THEN prd.calendar_year || ' Ozone Season'
+                                            when 'YEARRPT'  THEN prd.calendar_year || ' Year-to-Date'
+                                        end as period_description,
+                                        smv.parameter_cd,
+                                        typ.summary_num,   
+                                        typ.summary_type_cd,
+                                        typ.summary_name,
+                                        case ( typ.summary_type_cd )
+                                            when 'QTRRPT'   THEN smv.current_rpt_period_total
+                                            when 'YEARRPT'  THEN smv.year_total
+                                            when 'OSRPT'    THEN smv.os_total
+                                        end as summary_value
+                                  from  (
+                                            select  sel.mon_plan_id,
+                                                    sel.mon_loc_id,
+                                                    (
+                                                        select  sub.rpt_period_id
+                                                          from  camdecmpsmd.REPORTING_PERIOD sub
+                                                         where  sub.calendar_year = prd.calendar_year
+                                                           and  sub.quarter = max( prd.quarter )
+                                                    ) as rpt_period_id
+                                              from  (
+                                                        select  monitorplanid as mon_plan_id,
+                                                                reportingperiodids as rpt_period_id_list,
+                                                                locationid as mon_loc_id
+                                                    ) sel
+                                                    join camdecmpsmd.REPORTING_PERIOD prd
+                                                      on prd.rpt_period_id in ( select unnest( string_to_array( sel.rpt_period_id_list, ',' )::numeric[] ) )
+                                             group
+                                                by  sel.mon_plan_id,
+                                                    sel.mon_loc_id,
+                                                    prd.calendar_year
+                                        ) sel
+                                        join camdecmps.EMISSION_EVALUATION ems using ( mon_plan_id, rpt_period_id )
+                                        join camdecmpsmd.REPORTING_PERIOD prs using ( rpt_period_id )
+                                        join camdecmpsmd.REPORTING_PERIOD prd
+                                          on prd.calendar_year = prs.calendar_year
+                                         and prd.quarter <= prs.quarter
+                                        join camdecmps.MONITOR_PLAN_LOCATION mpl using ( mon_plan_id, mon_loc_id )
+                                        join camdecmps.SUMMARY_VALUE smv
+                                          on smv.rpt_period_id = prd.rpt_period_id
+                                         and smv.mon_loc_id = mpl.mon_loc_id
+                                         and smv.parameter_cd in ( 'CO2M', 'HIT', 'NOXM', 'NOXR', 'OPHOURS', 'OPTIME', 'SO2M' )
+                                        join (
+                                                select 'QTRRPT' as summary_type_cd, 'Quarterly Reported' as summary_name, 1 as summary_num union all
+                                                select 'OSRPT' as summary_type_cd, 'Ozone Season Reported' as summary_name, 2 as summary_num union all
+                                                select 'YEARRPT' as summary_type_cd, 'Year to Date Reported' as summary_name, 3 as summary_num
+                                             ) typ
+                                          on null is null
+                                 where  (
+                                            typ.summary_type_cd = 'QTRRPT'
+                                            or
+                                            prd.rpt_period_id = sel.rpt_period_id
+                                        )
+                                   and  not exists
+                                        (
+                                            select  1
+                                              from  camdecmpswks.EMISSION_EVALUATION exs
+                                             where  exs.rpt_period_id = prd.rpt_period_id -- uses prd instead of sel to include all quarters involved
+                                               and  exs.mon_plan_id = sel.mon_plan_id
+                                        )
+                            ) lst
+                     group
+                        by  lst.mon_loc_id,
+                            lst.rpt_period_id,
+                            lst.calendar_year,
+                            lst.period_description,
+                            lst.summary_num,   
+                            lst.summary_type_cd,
+                            lst.summary_name
+                    union   all
+                    select  lst.calendar_year,
+                            lst.period_description, 
+                            lst.summary_name as row_name,
+                            max( case when lst.parameter_cd = 'OPHOURS' then lst.summary_value end ) as op_hours,
+                            max( case when lst.parameter_cd = 'OPTIME' then lst.summary_value end ) as op_time,
+                            max( case when lst.parameter_cd = 'HIT' then lst.summary_value end ) as heat_input,
+                            max( case when lst.parameter_cd = 'SO2M' then lst.summary_value end ) as so2_mass,
+                            max( case when lst.parameter_cd = 'CO2M' then lst.summary_value end ) as co2_mass,
+                            max( case when lst.parameter_cd = 'NOXR' then lst.summary_value end ) as nox_rate,
+                            max( case when lst.parameter_cd = 'NOXM' then lst.summary_value end ) as nox_mass,
+                            lst.summary_num
+                      from  (
+                                select  smv.mon_loc_id,
+                                        smv.rpt_period_id,
+                                        prd.calendar_year,
+                                        case ( typ.summary_type_cd )
+                                            when 'QTRRPT'   THEN prd.period_description
+                                            when 'OSRPT'    THEN prd.calendar_year || ' Ozone Season'
+                                            when 'YEARRPT'  THEN prd.calendar_year || ' Year-to-Date'
+                                        end as period_description,
+                                        smv.parameter_cd,
+                                        typ.summary_num,   
+                                        typ.summary_type_cd,
+                                        typ.summary_name,
+                                        case ( typ.summary_type_cd )
+                                            when 'QTRRPT'   THEN smv.current_rpt_period_total
+                                            when 'YEARRPT'  THEN smv.year_total
+                                            when 'OSRPT'    THEN smv.os_total
+                                        end as summary_value
+                                  from  (
+                                            select  sel.mon_plan_id,
+                                                    sel.mon_loc_id,
+                                                    (
+                                                        select  sub.rpt_period_id
+                                                          from  camdecmpsmd.REPORTING_PERIOD sub
+                                                         where  sub.calendar_year = prd.calendar_year
+                                                           and  sub.quarter = max( prd.quarter )
+                                                    ) as rpt_period_id
+                                              from  (
+                                                        select  monitorplanid as mon_plan_id,
+                                                                reportingperiodids as rpt_period_id_list,
+                                                                locationid as mon_loc_id
+                                                    ) sel
+                                                    join camdecmpsmd.REPORTING_PERIOD prd
+                                                      on prd.rpt_period_id in ( select unnest( string_to_array( sel.rpt_period_id_list, ',' )::numeric[] ) )
+                                             group
+                                                by  sel.mon_plan_id,
+                                                    sel.mon_loc_id,
+                                                    prd.calendar_year
+                                        ) sel
+                                        join camdecmpswks.EMISSION_EVALUATION ems using ( mon_plan_id, rpt_period_id )
+                                        join camdecmpsmd.REPORTING_PERIOD prs using ( rpt_period_id )
+                                        join camdecmpsmd.REPORTING_PERIOD prd
+                                          on prd.calendar_year = prs.calendar_year
+                                         and prd.quarter <= prs.quarter
+                                        join camdecmpswks.MONITOR_PLAN_LOCATION mpl using ( mon_plan_id, mon_loc_id )
+                                        join camdecmpswks.SUMMARY_VALUE smv
+                                          on smv.rpt_period_id = prd.rpt_period_id
+                                         and smv.mon_loc_id = mpl.mon_loc_id
+                                         and smv.parameter_cd in ( 'CO2M', 'HIT', 'NOXM', 'NOXR', 'OPHOURS', 'OPTIME', 'SO2M' )
+                                        join (
+                                                select 'QTRRPT' as summary_type_cd, 'Quarterly Reported' as summary_name, 1 as summary_num union all
+                                                select 'OSRPT' as summary_type_cd, 'Ozone Season Reported' as summary_name, 2 as summary_num union all
+                                                select 'YEARRPT' as summary_type_cd, 'Year to Date Reported' as summary_name, 3 as summary_num
+                                             ) typ
+                                          on null is null
+                                 where  (
+                                            typ.summary_type_cd = 'QTRRPT'
+                                            or
+                                            prd.rpt_period_id = sel.rpt_period_id
+                                        )
+                            ) lst
+                     group
+                        by  lst.mon_loc_id,
+                            lst.rpt_period_id,
+                            lst.calendar_year,
+                            lst.period_description,
+                            lst.summary_num,   
+                            lst.summary_type_cd,
+                            lst.summary_name
+                ) cmb
+         order
+            by  calendar_year,
+                summary_num,
+                period_description;
+    
 END;
-$BODY$;
+$function$
+;


### PR DESCRIPTION
## Changes to both the camdecmps and camdecmpswks stored functions.

1. Added outer query with sort to ensure the rows display in the correct order.
2. Added controlling subquery to get the correct rows based on the reporting period list and to handle multiple years in the list.
3. Removed Calc summary type rows.
4. Corrected the Period Descriptions.