### PR TITLE
6792 Remove Duplication of QA Data on Eval and Submit Screens

### DIFF
--- a/camdecmpswks/views/vw_qa_cert_event_eval_and_submit.sql
+++ b/camdecmpswks/views/vw_qa_cert_event_eval_and_submit.sql
@@ -6,7 +6,7 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_qa_cert_event_eval_and_submit
  AS
  SELECT p.oris_code,
     p.facility_name,
-    mpl.mon_plan_id,
+    mp.mon_plan_id,
     COALESCE(u.unitid, sp.stack_name) AS location_info,
     qce.qa_cert_event_id,
     qce.qa_cert_event_cd,
@@ -33,7 +33,14 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_qa_cert_event_eval_and_submit
     sac.sub_avail_cd_description as submission_availability_cd_description
    FROM camd.plant p
      JOIN camdecmpswks.monitor_plan mp USING (fac_id)
-     JOIN camdecmpswks.monitor_plan_location mpl USING (mon_plan_id)
+     JOIN (select distinct mpl.mon_loc_id,
+				first_value(mp.mon_plan_id)
+			    over (
+			    	partition by mpl.mon_loc_id
+			        order by mp.begin_rpt_period_id desc
+			    ) latest_mon_plan_id
+			from camdecmpswks.monitor_plan_location mpl
+			inner join camdecmpswks.monitor_plan mp on mpl.mon_plan_id = mp.mon_plan_id) mpl ON mpl.latest_mon_plan_id = mp.mon_plan_Id
      JOIN camdecmpswks.monitor_location ml USING (mon_loc_id)
      JOIN camdecmpswks.qa_cert_event qce USING (mon_loc_id)
      JOIN camdecmpsmd.eval_status_code esc
@@ -43,5 +50,4 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_qa_cert_event_eval_and_submit
      LEFT JOIN camdecmpswks.monitor_system ms USING (mon_sys_id)
      LEFT JOIN camdecmpswks.component c USING (component_id)
      LEFT JOIN camd.unit u USING (unit_id)
-     LEFT JOIN camdecmps.stack_pipe sp USING (stack_pipe_id)
-  ORDER BY p.oris_code, mp.mon_plan_id, u.unitid, sp.stack_name, qce.qa_cert_event_date, qce.qa_cert_event_hour;
+     LEFT JOIN camdecmpswks.stack_pipe sp USING (stack_pipe_id);

--- a/camdecmpswks/views/vw_test_extension_exemption_eval_and_submit.sql
+++ b/camdecmpswks/views/vw_test_extension_exemption_eval_and_submit.sql
@@ -6,7 +6,7 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_test_extension_exemption_eval_and_submit
  AS
  SELECT p.oris_code,
     p.facility_name,
-    mpl.mon_plan_id,
+    mp.mon_plan_id,
     COALESCE(u.unitid, sp.stack_name) AS location_info,
     tee.test_extension_exemption_id,
     tee.extens_exempt_cd,
@@ -25,7 +25,14 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_test_extension_exemption_eval_and_submit
     rp.period_abbreviation
    FROM camd.plant p
      JOIN camdecmpswks.monitor_plan mp USING (fac_id)
-     JOIN camdecmpswks.monitor_plan_location mpl USING (mon_plan_id)
+     JOIN (select distinct mpl.mon_loc_id,
+				first_value(mp.mon_plan_id)
+			    over (
+			    	partition by mpl.mon_loc_id
+			        order by mp.begin_rpt_period_id desc
+			    ) latest_mon_plan_id
+			from camdecmpswks.monitor_plan_location mpl
+			inner join camdecmpswks.monitor_plan mp on mpl.mon_plan_id = mp.mon_plan_id) mpl ON mpl.latest_mon_plan_id = mp.mon_plan_Id
      JOIN camdecmpswks.monitor_location ml USING (mon_loc_id)
      JOIN camdecmpswks.test_extension_exemption tee USING (mon_loc_id)
      JOIN camdecmpsmd.eval_status_code esc
@@ -36,5 +43,4 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_test_extension_exemption_eval_and_submit
      LEFT JOIN camdecmpswks.component c USING (component_id)
      LEFT JOIN camdecmpsmd.reporting_period rp ON rp.rpt_period_id = tee.rpt_period_id
      LEFT JOIN camd.unit u USING (unit_id)
-     LEFT JOIN camdecmps.stack_pipe sp USING (stack_pipe_id)
-  ORDER BY p.oris_code, mp.mon_plan_id, u.unitid, sp.stack_name, tee.rpt_period_id;
+     LEFT JOIN camdecmpswks.stack_pipe sp USING (stack_pipe_id);

--- a/camdecmpswks/views/vw_test_summary_eval_and_submit.sql
+++ b/camdecmpswks/views/vw_test_summary_eval_and_submit.sql
@@ -6,7 +6,7 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_test_summary_eval_and_submit
  AS
  SELECT p.oris_code,
     p.facility_name,
-    mpl.mon_plan_id,
+    mp.mon_plan_id,
     COALESCE(u.unitid, sp.stack_name) AS location_info,
     ts.test_sum_id,
     ts.mon_loc_id,
@@ -36,7 +36,14 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_test_summary_eval_and_submit
     rp.period_abbreviation
    FROM camd.plant p
      JOIN camdecmpswks.monitor_plan mp USING (fac_id)
-     JOIN camdecmpswks.monitor_plan_location mpl USING (mon_plan_id)
+     JOIN (select distinct mpl.mon_loc_id,
+				first_value(mp.mon_plan_id)
+			    over (
+			    	partition by mpl.mon_loc_id
+			        order by mp.begin_rpt_period_id desc
+			    ) latest_mon_plan_id
+			from camdecmpswks.monitor_plan_location mpl
+			inner join camdecmpswks.monitor_plan mp on mpl.mon_plan_id = mp.mon_plan_id) mpl ON mpl.latest_mon_plan_id = mp.mon_plan_Id
      JOIN camdecmpswks.monitor_location ml USING (mon_loc_id)
      JOIN camdecmpswks.test_summary ts USING (mon_loc_id)
      JOIN camdecmpsmd.eval_status_code esc
@@ -48,5 +55,4 @@ CREATE OR REPLACE VIEW camdecmpswks.vw_test_summary_eval_and_submit
      LEFT JOIN camdecmpswks.component c ON c.component_id::text = ts.component_id::text
      LEFT JOIN camdecmpsmd.reporting_period rp ON rp.rpt_period_id = ts.rpt_period_id
      LEFT JOIN camd.unit u USING (unit_id)
-     LEFT JOIN camdecmps.stack_pipe sp USING (stack_pipe_id)
-  ORDER BY p.oris_code, mp.mon_plan_id, u.unitid, sp.stack_name, ts.test_type_cd, qsd.rpt_period_id, ts.end_date, ts.end_hour, ts.end_min;
+     LEFT JOIN camdecmpswks.stack_pipe sp USING (stack_pipe_id);

--- a/deployments/ecmps/release-v2.0-fix/Sprint33/6792/vw_qa_cert_event_eval_and_submit.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint33/6792/vw_qa_cert_event_eval_and_submit.sql
@@ -1,0 +1,53 @@
+-- View: camdecmpswks.vw_qa_cert_event_eval_and_submit
+
+--DROP VIEW IF EXISTS camdecmpswks.vw_qa_cert_event_eval_and_submit;
+
+CREATE OR REPLACE VIEW camdecmpswks.vw_qa_cert_event_eval_and_submit
+ AS
+ SELECT p.oris_code,
+    p.facility_name,
+    mp.mon_plan_id,
+    COALESCE(u.unitid, sp.stack_name) AS location_info,
+    qce.qa_cert_event_id,
+    qce.qa_cert_event_cd,
+    qce.mon_loc_id,
+    COALESCE(ms.system_identifier, c.component_identifier) AS system_component_identifier,
+        CASE
+            WHEN qce.qa_cert_event_date IS NULL THEN NULL::text
+            ELSE concat(qce.qa_cert_event_date, ' ', lpad(COALESCE(qce.qa_cert_event_hour, 0::numeric)::text, 2, '0'::text), ':00')
+        END AS event_date,
+        CASE
+            WHEN qce.conditional_data_begin_date IS NULL THEN NULL::text
+            ELSE concat(qce.conditional_data_begin_date, ' ', lpad(COALESCE(qce.conditional_data_begin_hour, 0::numeric)::text, 2, '0'::text), ':00')
+        END AS condition_date,
+        CASE
+            WHEN qce.last_test_completed_date IS NULL THEN NULL::text
+            ELSE concat(qce.last_test_completed_date, ' ', lpad(COALESCE(qce.last_test_completed_hour, 0::numeric)::text, 2, '0'::text), ':00')
+        END AS last_completion,
+    qce.required_test_cd,
+    qce.userid,
+    COALESCE(qce.update_date, qce.add_date) AS update_date,
+    qce.eval_status_cd,
+    esc.eval_status_cd_description,
+    qce.submission_availability_cd,
+    sac.sub_avail_cd_description as submission_availability_cd_description
+   FROM camd.plant p
+     JOIN camdecmpswks.monitor_plan mp USING (fac_id)
+     JOIN (select distinct mpl.mon_loc_id,
+				first_value(mp.mon_plan_id)
+			    over (
+			    	partition by mpl.mon_loc_id
+			        order by mp.begin_rpt_period_id desc
+			    ) latest_mon_plan_id
+			from camdecmpswks.monitor_plan_location mpl
+			inner join camdecmpswks.monitor_plan mp on mpl.mon_plan_id = mp.mon_plan_id) mpl ON mpl.latest_mon_plan_id = mp.mon_plan_Id
+     JOIN camdecmpswks.monitor_location ml USING (mon_loc_id)
+     JOIN camdecmpswks.qa_cert_event qce USING (mon_loc_id)
+     JOIN camdecmpsmd.eval_status_code esc
+	 	ON esc.eval_status_cd = qce.eval_status_cd
+	 JOIN camdecmpsmd.submission_availability_code sac
+	 	ON sac.submission_availability_cd = qce.submission_availability_cd	 
+     LEFT JOIN camdecmpswks.monitor_system ms USING (mon_sys_id)
+     LEFT JOIN camdecmpswks.component c USING (component_id)
+     LEFT JOIN camd.unit u USING (unit_id)
+     LEFT JOIN camdecmpswks.stack_pipe sp USING (stack_pipe_id);

--- a/deployments/ecmps/release-v2.0-fix/Sprint33/6792/vw_test_extension_exemption_eval_and_submit.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint33/6792/vw_test_extension_exemption_eval_and_submit.sql
@@ -1,0 +1,46 @@
+-- View: camdecmpswks.vw_test_extension_exemption_eval_and_submit
+
+--DROP VIEW IF EXISTS camdecmpswks.vw_test_extension_exemption_eval_and_submit;
+
+CREATE OR REPLACE VIEW camdecmpswks.vw_test_extension_exemption_eval_and_submit
+ AS
+ SELECT p.oris_code,
+    p.facility_name,
+    mp.mon_plan_id,
+    COALESCE(u.unitid, sp.stack_name) AS location_info,
+    tee.test_extension_exemption_id,
+    tee.extens_exempt_cd,
+    tee.mon_loc_id,
+    COALESCE(ms.system_identifier, c.component_identifier) AS system_component_identifier,
+    tee.rpt_period_id,
+    tee.userid,
+    COALESCE(tee.update_date, tee.add_date) AS update_date,
+    tee.eval_status_cd,
+    esc.eval_status_cd_description,
+    tee.submission_availability_cd,
+    sac.sub_avail_cd_description as submission_availability_cd_description,
+	tee.fuel_cd,
+    tee.hours_used,
+    tee.span_scale_cd,
+    rp.period_abbreviation
+   FROM camd.plant p
+     JOIN camdecmpswks.monitor_plan mp USING (fac_id)
+     JOIN (select distinct mpl.mon_loc_id,
+				first_value(mp.mon_plan_id)
+			    over (
+			    	partition by mpl.mon_loc_id
+			        order by mp.begin_rpt_period_id desc
+			    ) latest_mon_plan_id
+			from camdecmpswks.monitor_plan_location mpl
+			inner join camdecmpswks.monitor_plan mp on mpl.mon_plan_id = mp.mon_plan_id) mpl ON mpl.latest_mon_plan_id = mp.mon_plan_Id
+     JOIN camdecmpswks.monitor_location ml USING (mon_loc_id)
+     JOIN camdecmpswks.test_extension_exemption tee USING (mon_loc_id)
+     JOIN camdecmpsmd.eval_status_code esc
+	 	ON esc.eval_status_cd = tee.eval_status_cd
+	 JOIN camdecmpsmd.submission_availability_code sac
+	 	ON sac.submission_availability_cd = tee.submission_availability_cd
+     LEFT JOIN camdecmpswks.monitor_system ms USING (mon_sys_id)
+     LEFT JOIN camdecmpswks.component c USING (component_id)
+     LEFT JOIN camdecmpsmd.reporting_period rp ON rp.rpt_period_id = tee.rpt_period_id
+     LEFT JOIN camd.unit u USING (unit_id)
+     LEFT JOIN camdecmpswks.stack_pipe sp USING (stack_pipe_id);

--- a/deployments/ecmps/release-v2.0-fix/Sprint33/6792/vw_test_summary_eval_and_submit.sql
+++ b/deployments/ecmps/release-v2.0-fix/Sprint33/6792/vw_test_summary_eval_and_submit.sql
@@ -1,0 +1,58 @@
+-- View: camdecmpswks.vw_test_summary_eval_and_submit
+
+--DROP VIEW IF EXISTS camdecmpswks.vw_test_summary_eval_and_submit;
+
+CREATE OR REPLACE VIEW camdecmpswks.vw_test_summary_eval_and_submit
+ AS
+ SELECT p.oris_code,
+    p.facility_name,
+    mp.mon_plan_id,
+    COALESCE(u.unitid, sp.stack_name) AS location_info,
+    ts.test_sum_id,
+    ts.mon_loc_id,
+    COALESCE(ms.system_identifier, c.component_identifier) AS system_component_identifier,
+    ts.test_num,
+    ts.gp_ind,
+    ts.test_type_cd,
+    ts.test_reason_cd,
+    ts.test_result_cd,
+    qsd.rpt_period_id,
+        CASE
+            WHEN ts.begin_date IS NULL THEN NULL::text
+            ELSE concat(ts.begin_date, ' ', lpad(COALESCE(ts.begin_hour, 0::numeric)::text, 2, '0'::text), ':', lpad(COALESCE(ts.begin_min, 0::numeric)::text, 2, '0'::text))
+        END AS begin_date,
+        CASE
+            WHEN ts.end_date IS NULL THEN NULL::text
+            ELSE concat(ts.end_date, ' ', lpad(COALESCE(ts.end_hour, 0::numeric)::text, 2, '0'::text), ':', lpad(COALESCE(ts.end_min, 0::numeric)::text, 2, '0'::text))
+        END AS end_date,
+    ts.updated_status_flg,
+    ts.userid,
+    ts.add_date,
+    COALESCE(ts.update_date, ts.add_date) AS update_date,
+    ts.eval_status_cd,
+    esc.eval_status_cd_description,
+    qsd.submission_availability_cd,
+    sac.sub_avail_cd_description as submission_availability_cd_description,
+    rp.period_abbreviation
+   FROM camd.plant p
+     JOIN camdecmpswks.monitor_plan mp USING (fac_id)
+     JOIN (select distinct mpl.mon_loc_id,
+				first_value(mp.mon_plan_id)
+			    over (
+			    	partition by mpl.mon_loc_id
+			        order by mp.begin_rpt_period_id desc
+			    ) latest_mon_plan_id
+			from camdecmpswks.monitor_plan_location mpl
+			inner join camdecmpswks.monitor_plan mp on mpl.mon_plan_id = mp.mon_plan_id) mpl ON mpl.latest_mon_plan_id = mp.mon_plan_Id
+     JOIN camdecmpswks.monitor_location ml USING (mon_loc_id)
+     JOIN camdecmpswks.test_summary ts USING (mon_loc_id)
+     JOIN camdecmpsmd.eval_status_code esc
+	 	ON esc.eval_status_cd = ts.eval_status_cd
+     LEFT JOIN camdecmpswks.qa_supp_data qsd USING (test_sum_id)
+	 LEFT JOIN camdecmpsmd.submission_availability_code sac
+	 	ON sac.submission_availability_cd = qsd.submission_availability_cd	 
+	 LEFT JOIN camdecmpswks.monitor_system ms ON ms.mon_sys_id::text = ts.mon_sys_id::text
+     LEFT JOIN camdecmpswks.component c ON c.component_id::text = ts.component_id::text
+     LEFT JOIN camdecmpsmd.reporting_period rp ON rp.rpt_period_id = ts.rpt_period_id
+     LEFT JOIN camd.unit u USING (unit_id)
+     LEFT JOIN camdecmpswks.stack_pipe sp USING (stack_pipe_id);


### PR DESCRIPTION
update views used to retrieve QA data for eval and submit screens to always link to the latest MP (based on MP begin rpt period)

views also updated to use camdecmpswks stack_pipe table (instead of camdecmps table)