### PR TITLE
Units Expected to Submit report fixes (7175, 7188)

### DIFF
--- a/deployments/ecmps/release-v2.2/Sprint41/7175/get_units_expected_to_submit_report_data.sql
+++ b/deployments/ecmps/release-v2.2/Sprint41/7175/get_units_expected_to_submit_report_data.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS camdecmpsaux.get_units_expected_to_submit_report_data(numeric, character varying, character varying, character varying, numeric, numeric, character varying) CASCADE;
-
 create or replace
 function camdecmpsaux.get_units_expected_to_submit_report_data(
     V_FAC_ID numeric,


### PR DESCRIPTION
7175
 - use left join to vw_monitor_plan to include units that currently have no active monitoring plan active for the selected year and quarter
 - return MP status in place of location list when unit does not have an MP for the selected year and quarter

7188
 - remove requirement to pass in program (code already handled the possibility of a null value
 - move window status condition to a WHERE clause (to correctly apply the condition after the correct window status is determined for the MP for the quarter)