### PR TITLE
6745 - Submission Audit Query Updates

### DIFF
--- a/camdecmpsaux/constraints-indexes/2-submission_queue.sql
+++ b/camdecmpsaux/constraints-indexes/2-submission_queue.sql
@@ -43,3 +43,15 @@ CREATE INDEX IF NOT EXISTS idx_submission_queue_severity_cd
 CREATE INDEX IF NOT EXISTS idx_submission_queue_status_cd
     ON camdecmpsaux.submission_queue USING btree
     (status_cd COLLATE pg_catalog."default" ASC NULLS LAST);
+	
+CREATE INDEX IF NOT EXISTS idx_submission_queue_completed_time 
+	ON camdecmpsaux.submission_queue USING btree 
+	(completed_time);
+
+CREATE INDEX IF NOT EXISTS idx_submission_queue_started_time 
+	ON camdecmpsaux.submission_queue USING btree 
+	(started_time);
+
+CREATE INDEX IF NOT EXISTS idx_submission_queue_queued_time 
+	ON camdecmpsaux.submission_queue
+	((queued_time::date));	

--- a/camdecmpsaux/functions/get_submission_audit_data.sql
+++ b/camdecmpsaux/functions/get_submission_audit_data.sql
@@ -135,7 +135,8 @@ BEGIN
 		'Event' as qa_type,
 		'Code ' || qce_wks.qa_cert_event_cd || 
 		' Date/Hour ' || to_char(qce_wks.qa_cert_event_date, 'mm/dd/yyyy') || ' ' || qce_wks.qa_cert_event_hour || 
-		case when qce_wks.mon_sys_id is not null then ' System ID ' || ms.system_identifier when qce_wks.component_id is not null then ' Comp ID ' || c.component_identifier else '' end as qa_identifier,
+		case when qce_wks.mon_sys_id is not null then ' System ID ' || ms.system_identifier else '' end ||
+        case when qce_wks.component_id is not null then ' Comp ID ' || c.component_identifier else '' end as qa_identifier,
 		coalesce(sq.user_id , '') as submitter,
 		qa_qce_sq.submission_id as loaded_submission_id,
 		qa_qce_sq.queued_time as loaded_submission_date
@@ -171,7 +172,8 @@ BEGIN
 		sq.status_cd || ': ' || sq.note as queue_status,
 		'Extension/Exemption' as qa_type,
 		'Code ' || tee_wks.extens_exempt_cd || 
-		case when tee_wks.mon_sys_id is not null then ' System ID ' || ms.system_identifier when tee_wks.component_id is not null then ' Comp ID ' || c.component_identifier else '' end as qa_identifier,
+		case when tee_wks.mon_sys_id is not null then ' System ID ' || ms.system_identifier else '' end ||
+        case when tee_wks.component_id is not null then ' Comp ID ' || c.component_identifier else '' end as qa_identifier,
 		coalesce(sq.user_id , '') as submitter,
 		qa_tee_sq.submission_id as loaded_submission_id,
 		qa_tee_sq.queued_time as loaded_submission_date

--- a/camdecmpsaux/functions/get_submission_audit_data.sql
+++ b/camdecmpsaux/functions/get_submission_audit_data.sql
@@ -133,7 +133,9 @@ BEGIN
 		sq.submission_set,
 		sq.status_cd || ': ' || sq.note as queue_status,
 		'Event' as qa_type,
-		'Code ' || qce_wks.qa_cert_event_cd || ' Date/Hour ' || to_char(qce_wks.qa_cert_event_date, 'mm/dd/yyyy') || ' ' || qce_wks.qa_cert_event_hour as qa_identifier,
+		'Code ' || qce_wks.qa_cert_event_cd || 
+		' Date/Hour ' || to_char(qce_wks.qa_cert_event_date, 'mm/dd/yyyy') || ' ' || qce_wks.qa_cert_event_hour || 
+		case when qce_wks.mon_sys_id is not null then ' System ID ' || ms.system_identifier when qce_wks.component_id is not null then ' Comp ID ' || c.component_identifier else '' end as qa_identifier,
 		coalesce(sq.user_id , '') as submitter,
 		qa_qce_sq.submission_id as loaded_submission_id,
 		qa_qce_sq.queued_time as loaded_submission_date
@@ -147,6 +149,10 @@ BEGIN
 		and qce.submission_id = qa_qce_sq.submission_id
 	join camdecmpswks.qa_cert_event qce_wks on
 		sq.qa_cert_event_id = qce_wks.qa_cert_event_id
+    left join camdecmpswks.monitor_system ms on
+		qce_wks.mon_sys_id = ms.mon_sys_id
+    left join camdecmpswks.component c on
+		qce_wks.component_id = c.component_id
 	where
 		sq.process_cd = 'QA'
 		and sq.submission_id > coalesce(qa_qce_sq.submission_id, 0)
@@ -164,7 +170,8 @@ BEGIN
 		sq.submission_set,
 		sq.status_cd || ': ' || sq.note as queue_status,
 		'Extension/Exemption' as qa_type,
-		'Code ' || tee_wks.extens_exempt_cd as qa_identifier,
+		'Code ' || tee_wks.extens_exempt_cd || 
+		case when tee_wks.mon_sys_id is not null then ' System ID ' || ms.system_identifier when tee_wks.component_id is not null then ' Comp ID ' || c.component_identifier else '' end as qa_identifier,
 		coalesce(sq.user_id , '') as submitter,
 		qa_tee_sq.submission_id as loaded_submission_id,
 		qa_tee_sq.queued_time as loaded_submission_date
@@ -178,6 +185,10 @@ BEGIN
 		and tee.submission_id = qa_tee_sq.submission_id
 	join camdecmpswks.test_extension_exemption tee_wks on
 		sq.test_extension_exemption_id = tee_wks.test_extension_exemption_id
+    left join camdecmpswks.monitor_system ms on
+		tee_wks.mon_sys_id = ms.mon_sys_id
+    left join camdecmpswks.component c on
+		tee_wks.component_id = c.component_id
 	where
 		sq.process_cd = 'QA'
 		and sq.submission_id > coalesce(qa_tee_sq.submission_id, 0)

--- a/camdecmpsaux/functions/get_submission_audit_data.sql
+++ b/camdecmpsaux/functions/get_submission_audit_data.sql
@@ -12,7 +12,7 @@ RETURNS TABLE (
     FACILITY_NAME                   CHARACTER VARYING,
     STATE                           CHARACTER VARYING,
     LOCATIONS                       TEXT,
-    PERIOD                          CHARACTER VARYING,
+    PERIOD                          TEXT,
     FILE_TYPE_CD                    CHARACTER VARYING,
     SUBMISSION_ID                   BIGINT,
     SUBMISSION_DATE                 TIMESTAMP,
@@ -26,163 +26,226 @@ RETURNS TABLE (
 ) AS $BODY$
 BEGIN
     RETURN QUERY
-    select
-		vmp.oris_code,
-		vmp.facility_name,
-		vmp.state,
-		vmp.locations,
-		rp.period_abbreviation as period,
-		sq.process_cd as file_type_cd,
-		sq.submission_id,
-		sq.queued_time as submission_date,
-		(
+    with sq_filtered as (
 		select
-			string_agg(sq_sub.submission_id::text, ',')
-		from
-			camdecmpsaux.submission_queue sq_sub
-		where
-			sq_sub.submission_set_id = ss.submission_set_id) as submission_set,
-		sq.status_cd || ': ' || sq.note || case
-			when sq.process_cd = 'EM'
-			and not exists (
-			select
-					pr.pdem_report_id
-			from
-					camdecmpsaux.pdem_report pr
-			where
-					pr.submission_id = sq.submission_id
-				and pr.status_cd = 'COMPLETE')
-			then ' (PDEM missing)'
-	    else ''
-		end as queue_status,
-		case
-			when sq.process_cd = 'QA'
-			and sq.test_sum_id is not null then 'Test'
-			when sq.process_cd = 'QA'
-			and sq.qa_cert_event_id is not null then 'Event'
-			when sq.process_cd = 'QA'
-			and sq.test_extension_exemption_id is not null then 'Extension/Exemption'
-			else null
-		end as qa_type,
-		case
-			when sq.process_cd = 'QA'
-			and sq.test_sum_id is not null then qsd_wks.test_type_cd || ' ' || qsd_wks.test_num
-			when sq.process_cd = 'QA'
-			and sq.qa_cert_event_id is not null then 'Code ' || qce_wks.qa_cert_event_cd || ' Date/Hour ' || to_char(qce_wks.qa_cert_event_date, 'mm/dd/yyyy') || ' ' || qce_wks.qa_cert_event_hour
-			when sq.process_cd = 'QA'
-			and sq.test_extension_exemption_id is not null then 'Code ' || tee_wks.extens_exempt_cd
-			else null
-		end as qa_identifier,
-		coalesce(ss.user_id , '') as submitter,
-		case
-			when sq.process_cd = 'EM' then ee_sq.submission_id
-			when sq.process_cd = 'MP' then mp_sq.submission_id
-			when sq.process_cd = 'QA'
-			and sq.test_sum_id is not null then qa_ts_sq.submission_id
-			when sq.process_cd = 'QA'
-			and sq.qa_cert_event_id is not null then qa_qce_sq.submission_id
-			when sq.process_cd = 'QA'
-			and sq.test_extension_exemption_id is not null then qa_tee_sq.submission_id
-			else null
-		end as loaded_submission_id,
-		case
-			when sq.process_cd = 'EM' then ee_sq.queued_time
-			when sq.process_cd = 'MP' then mp_sq.queued_time
-			when sq.process_cd = 'QA'
-			and sq.test_sum_id is not null then qa_ts_sq.queued_time
-			when sq.process_cd = 'QA'
-			and sq.qa_cert_event_id is not null then qa_qce_sq.queued_time
-			when sq.process_cd = 'QA'
-			and sq.test_extension_exemption_id is not null then qa_tee_sq.queued_time
-			else null
-		end as loaded_submission_date
-	from
-		camdecmpsaux.submission_set ss
-	join camdecmpsaux.submission_queue sq on
-		ss.submission_set_id = sq.submission_set_id
+			sq.process_cd,
+			sq.submission_id,
+			sq.queued_time,
+			sq.status_cd,
+			sq.note,
+			sq.test_sum_id,
+			sq.qa_cert_Event_id,
+			sq.test_extension_exemption_id,
+			sq.submission_set_id,
+			sq.rpt_period_id,
+			ss.mon_plan_id,
+			(select string_agg(sq_sub.submission_id::text, ',')
+			   from	camdecmpsaux.submission_queue sq_sub
+			  where	sq_sub.submission_set_id = ss.submission_set_id) as submission_set,
+			ss.user_id,
+			vmp.oris_code,
+			vmp.facility_name,
+			vmp.state,
+			vmp.locations,
+			mp.submission_id as mp_submission_id
+		from camdecmpsaux.submission_queue sq
+		join camdecmpsaux.submission_set ss on
+			sq.submission_set_id = ss.submission_set_id
+		join camdecmps.vw_monitor_plan vmp on
+			ss.mon_plan_id = vmp.mon_plan_id
+		join camdecmps.monitor_plan mp on
+			vmp.mon_plan_id = mp.mon_plan_id
+		where sq.submission_id > 0
 		and sq.queued_time is not null
 		and (sq.STARTED_TIME is null
 			or sq.COMPLETED_TIME is null
 			or sq.STATUS_CD = 'WIP')
-		AND date_trunc('day', sq.queued_time) BETWEEN COALESCE(v_begin_date, to_date('04/01/2026', 'mm/dd/yyyy')) AND COALESCE(v_end_date, now())
-		AND sq.process_cd = coalesce(v_file_type_cd, sq.process_cd)
-	join camdecmps.vw_monitor_plan vmp on
-		ss.mon_plan_id = vmp.mon_plan_id
-		AND vmp.oris_code = coalesce(v_oris_code, vmp.oris_code)
-		AND vmp.facility_name = coalesce(v_facility_name, vmp.facility_name)
-	join camdecmps.monitor_plan mp on
-		vmp.mon_plan_id = mp.mon_plan_id
-	left join camdecmpsmd.reporting_period rp on
-		sq.rpt_period_id = rp.rpt_period_id
-	left join camdecmps.emission_evaluation ee on
-		ss.mon_plan_id = ee.mon_plan_id
-		and coalesce(sq.rpt_period_id, 0) = ee.rpt_period_id
-	left join camdecmpsaux.submission_queue ee_sq on
-		ee.submission_id = ee_sq.submission_id
+		AND date_trunc('day', sq.queued_time) BETWEEN COALESCE(V_BEGIN_DATE, to_date('04/01/2026', 'mm/dd/yyyy')) AND COALESCE(V_END_DATE, date_trunc('day', now()))
+		AND sq.process_cd = coalesce(V_FILE_TYPE_CD, sq.process_cd)
+		AND vmp.oris_code = coalesce(V_ORIS_CODE, vmp.oris_code)
+		AND vmp.facility_name = coalesce(V_FACILITY_NAME, vmp.facility_name)
+	)
+	select
+		sq.oris_code,
+		sq.facility_name,
+		sq.state,
+		sq.locations,
+		null as period,
+		sq.process_cd as file_type_cd,
+		sq.submission_id,
+		sq.queued_time as submission_date,
+		sq.submission_set,
+		sq.status_cd || ': ' || sq.note as queue_status,
+		null as qa_type,
+		null as qa_identifier,
+		coalesce(sq.user_id , '') as submitter,
+		mp_sq.submission_id as loaded_submission_id,
+		mp_sq.queued_time as loaded_submission_date
+	from
+		sq_filtered sq
 	left join camdecmpsaux.submission_queue mp_sq on
-		mp.submission_id = mp_sq.submission_id
+		mp_sq.process_cd = 'MP'
+		and sq.mp_submission_id = mp_sq.submission_id
+	where
+		sq.process_cd = 'MP'
+		and sq.submission_id > coalesce(mp_sq.submission_id, 0)
+	union all
+	select
+		sq.oris_code,
+		sq.facility_name,
+		sq.state,
+		sq.locations,
+		null as period,
+		sq.process_cd as file_type_cd,
+		sq.submission_id,
+		sq.queued_time as submission_date,
+		sq.submission_set,
+		sq.status_cd || ': ' || sq.note as queue_status,
+		'Test' as qa_type,
+		qsd_wks.test_type_cd || ' ' || qsd_wks.test_num as qa_identifier,
+		coalesce(sq.user_id , '') as submitter,
+		qa_ts_sq.submission_id as loaded_submission_id,
+		qa_ts_sq.queued_time as loaded_submission_date
+	from
+		sq_filtered sq
 	left join camdecmps.qa_supp_data qsd on
 		sq.test_sum_id = qsd.test_sum_id
 	left join camdecmpsaux.submission_queue qa_ts_sq on
-		qsd.submission_id = qa_ts_sq.submission_id
+		qa_ts_sq.process_cd = 'QA'
+		and qa_ts_sq.test_sum_id = qsd.test_sum_id 
+		and qsd.submission_id = qa_ts_sq.submission_id
+	join camdecmpswks.qa_supp_data qsd_wks on
+		sq.test_sum_id = qsd_wks.test_sum_Id
+	where
+		sq.process_cd = 'QA'
+		and sq.submission_id > coalesce(qa_ts_sq.submission_id, 0)
+		and sq.test_sum_id is not null
+	union all
+	select
+		sq.oris_code,
+		sq.facility_name,
+		sq.state,
+		sq.locations,
+		null as period,
+		sq.process_cd as file_type_cd,
+		sq.submission_id,
+		sq.queued_time as submission_date,
+		sq.submission_set,
+		sq.status_cd || ': ' || sq.note as queue_status,
+		'Event' as qa_type,
+		'Code ' || qce_wks.qa_cert_event_cd || ' Date/Hour ' || to_char(qce_wks.qa_cert_event_date, 'mm/dd/yyyy') || ' ' || qce_wks.qa_cert_event_hour as qa_identifier,
+		coalesce(sq.user_id , '') as submitter,
+		qa_qce_sq.submission_id as loaded_submission_id,
+		qa_qce_sq.queued_time as loaded_submission_date
+	from
+		sq_filtered sq
 	left join camdecmps.qa_cert_event qce on
 		sq.qa_cert_event_id = qce.qa_cert_event_id
 	left join camdecmpsaux.submission_queue qa_qce_sq on
-		qce.submission_id = qa_qce_sq.submission_id
+		qa_qce_sq.process_cd = 'QA'
+		and qa_qce_sq.qa_cert_event_id = qce.qa_cert_event_id
+		and qce.submission_id = qa_qce_sq.submission_id
+	join camdecmpswks.qa_cert_event qce_wks on
+		sq.qa_cert_event_id = qce_wks.qa_cert_event_id
+	where
+		sq.process_cd = 'QA'
+		and sq.submission_id > coalesce(qa_qce_sq.submission_id, 0)
+		and sq.qa_cert_event_id is not null
+	union all
+	select
+		sq.oris_code,
+		sq.facility_name,
+		sq.state,
+		sq.locations,
+		null as period,
+		sq.process_cd as file_type_cd,
+		sq.submission_id,
+		sq.queued_time as submission_date,
+		sq.submission_set,
+		sq.status_cd || ': ' || sq.note as queue_status,
+		'Extension/Exemption' as qa_type,
+		'Code ' || tee_wks.extens_exempt_cd as qa_identifier,
+		coalesce(sq.user_id , '') as submitter,
+		qa_tee_sq.submission_id as loaded_submission_id,
+		qa_tee_sq.queued_time as loaded_submission_date
+	from
+		sq_filtered sq
 	left join camdecmps.test_extension_exemption tee on
 		sq.test_extension_exemption_id = tee.test_extension_exemption_id
 	left join camdecmpsaux.submission_queue qa_tee_sq on
-		tee.submission_id = qa_tee_sq.submission_id
-	left join camdecmpswks.qa_supp_data qsd_wks on
-		sq.test_sum_id = qsd_wks.test_sum_Id
-	left join camdecmpswks.qa_cert_event qce_wks on
-		sq.qa_cert_event_id = qce_wks.qa_cert_event_id
-	left join camdecmpswks.test_extension_exemption tee_wks on
+		qa_tee_sq.process_cd = 'QA'
+		and qa_tee_sq.test_extension_exemption_id = tee.test_extension_exemption_id
+		and tee.submission_id = qa_tee_sq.submission_id
+	join camdecmpswks.test_extension_exemption tee_wks on
 		sq.test_extension_exemption_id = tee_wks.test_extension_exemption_id
 	where
-		sq.submission_id > 0
+		sq.process_cd = 'QA'
+		and sq.submission_id > coalesce(qa_tee_sq.submission_id, 0)
+		and sq.test_extension_exemption_id is not null
+	union all
+	select
+		sq.oris_code,
+		sq.facility_name,
+		sq.state,
+		sq.locations,
+		rp.period_abbreviation as period,
+		sq.process_cd as file_type_cd,
+		sq.submission_id,
+		sq.queued_time as submission_date,
+		sq.submission_set,
+		sq.status_cd || ': ' || sq.note || case
+			when not exists (
+			select
+				pr.pdem_report_id
+			from
+				camdecmpsaux.pdem_report pr
+			where
+				pr.mon_plan_id = sq.mon_plan_id 
+				and pr.rpt_period_id = sq.rpt_period_id 
+				and pr.submission_id >= sq.submission_id 
+				and pr.status_cd = 'COMPLETE')
+			then ' (PDEM missing)'
+	    else ''
+		end as queue_status,
+		null as qa_type,
+		null as qa_identifier,
+		coalesce(sq.user_id , '') as submitter,
+		ee_sq.submission_id as loaded_submission_id,
+		ee_sq.queued_time as loaded_submission_date
+	from
+		sq_filtered sq
+	left join camdecmpsmd.reporting_period rp on
+		sq.rpt_period_id = rp.rpt_period_id
+	left join camdecmps.emission_evaluation ee on
+		sq.mon_plan_id = ee.mon_plan_id
+		and coalesce(sq.rpt_period_id, 0) = ee.rpt_period_id
+	left join camdecmpsaux.submission_queue ee_sq on
+		ee_sq.process_cd = 'EM'
+		and ee_sq.rpt_period_id = ee.rpt_period_id 
+		and ee.submission_id = ee_sq.submission_id
+	where
+		sq.process_cd = 'EM'
 		and 
 		(
-			sq.submission_id > coalesce(case
-				when sq.process_cd = 'EM' then ee_sq.submission_id
-				when sq.process_cd = 'MP' then mp_sq.submission_id
-				when sq.process_cd = 'QA' and sq.test_sum_id is not null then qa_ts_sq.submission_id		
-				when sq.process_cd = 'QA' and sq.qa_cert_event_id is not null then qa_qce_sq.submission_id		
-				when sq.process_cd = 'QA' and sq.test_extension_exemption_id is not null then qa_tee_sq.submission_id
-				else null
-			end, 0)
+			sq.submission_id > coalesce(ee_sq.submission_id, 0)
 			or
-			( sq.process_cd = 'EM'
-				and sq.submission_id = ee_sq.submission_id
-				and not exists (
+			not exists (
 				select
 					pr.pdem_report_id
 				from
 					camdecmpsaux.pdem_report pr
 				where
-					pr.submission_id = sq.submission_id
+					pr.mon_plan_id = sq.mon_plan_id 
+					and pr.rpt_period_id = sq.rpt_period_id 
+					and pr.submission_id >= sq.submission_id 
 					and pr.status_cd = 'COMPLETE')
-			)
 		)
-		and (
-			sq.process_cd <> 'QA'
-			or
-			(
-				sq.process_cd = 'QA' 
-				and
-				(
-					(sq.test_sum_id is not null and qsd_wks.test_sum_id is not null)
-					or
-					(sq.qa_cert_event_id is not null and qce_wks.qa_cert_event_id is not null)
-					or
-					(sq.test_extension_exemption_id is not null and tee_wks.test_extension_exemption_id is not null)
-				)
-			)
-		)
-	order by
-		sq.process_cd,
-		sq.queued_time desc,
-		sq.submission_id;
+	order by 
+		file_type_cd,
+		submission_date desc,
+		submission_id;
+
+
 
 
 END;

--- a/deployments/ecmps/release-v2.2/Sprint41/6745/get_submission_audit_data.sql
+++ b/deployments/ecmps/release-v2.2/Sprint41/6745/get_submission_audit_data.sql
@@ -135,7 +135,8 @@ BEGIN
 		'Event' as qa_type,
 		'Code ' || qce_wks.qa_cert_event_cd || 
 		' Date/Hour ' || to_char(qce_wks.qa_cert_event_date, 'mm/dd/yyyy') || ' ' || qce_wks.qa_cert_event_hour || 
-		case when qce_wks.mon_sys_id is not null then ' System ID ' || ms.system_identifier when qce_wks.component_id is not null then ' Comp ID ' || c.component_identifier else '' end as qa_identifier,
+		case when qce_wks.mon_sys_id is not null then ' System ID ' || ms.system_identifier else '' end ||
+        case when qce_wks.component_id is not null then ' Comp ID ' || c.component_identifier else '' end as qa_identifier,
 		coalesce(sq.user_id , '') as submitter,
 		qa_qce_sq.submission_id as loaded_submission_id,
 		qa_qce_sq.queued_time as loaded_submission_date
@@ -171,7 +172,8 @@ BEGIN
 		sq.status_cd || ': ' || sq.note as queue_status,
 		'Extension/Exemption' as qa_type,
 		'Code ' || tee_wks.extens_exempt_cd || 
-		case when tee_wks.mon_sys_id is not null then ' System ID ' || ms.system_identifier when tee_wks.component_id is not null then ' Comp ID ' || c.component_identifier else '' end as qa_identifier,
+		case when tee_wks.mon_sys_id is not null then ' System ID ' || ms.system_identifier else '' end ||
+        case when tee_wks.component_id is not null then ' Comp ID ' || c.component_identifier else '' end as qa_identifier,
 		coalesce(sq.user_id , '') as submitter,
 		qa_tee_sq.submission_id as loaded_submission_id,
 		qa_tee_sq.queued_time as loaded_submission_date

--- a/deployments/ecmps/release-v2.2/Sprint41/6745/get_submission_audit_data.sql
+++ b/deployments/ecmps/release-v2.2/Sprint41/6745/get_submission_audit_data.sql
@@ -179,6 +179,8 @@ BEGIN
 				)
 			)
 		)
+		and sq.note not like '%duplicate key value violates unique constraint%'
+		and sq.note not like '%ENOSPC: no space left on device, mkdir%'
 	order by
 		sq.process_cd,
 		sq.queued_time desc,

--- a/deployments/ecmps/release-v2.2/Sprint41/6745/get_submission_audit_data.sql
+++ b/deployments/ecmps/release-v2.2/Sprint41/6745/get_submission_audit_data.sql
@@ -133,7 +133,9 @@ BEGIN
 		sq.submission_set,
 		sq.status_cd || ': ' || sq.note as queue_status,
 		'Event' as qa_type,
-		'Code ' || qce_wks.qa_cert_event_cd || ' Date/Hour ' || to_char(qce_wks.qa_cert_event_date, 'mm/dd/yyyy') || ' ' || qce_wks.qa_cert_event_hour as qa_identifier,
+		'Code ' || qce_wks.qa_cert_event_cd || 
+		' Date/Hour ' || to_char(qce_wks.qa_cert_event_date, 'mm/dd/yyyy') || ' ' || qce_wks.qa_cert_event_hour || 
+		case when qce_wks.mon_sys_id is not null then ' System ID ' || ms.system_identifier when qce_wks.component_id is not null then ' Comp ID ' || c.component_identifier else '' end as qa_identifier,
 		coalesce(sq.user_id , '') as submitter,
 		qa_qce_sq.submission_id as loaded_submission_id,
 		qa_qce_sq.queued_time as loaded_submission_date
@@ -147,6 +149,10 @@ BEGIN
 		and qce.submission_id = qa_qce_sq.submission_id
 	join camdecmpswks.qa_cert_event qce_wks on
 		sq.qa_cert_event_id = qce_wks.qa_cert_event_id
+    left join camdecmpswks.monitor_system ms on
+		qce_wks.mon_sys_id = ms.mon_sys_id
+    left join camdecmpswks.component c on
+		qce_wks.component_id = c.component_id
 	where
 		sq.process_cd = 'QA'
 		and sq.submission_id > coalesce(qa_qce_sq.submission_id, 0)
@@ -164,7 +170,8 @@ BEGIN
 		sq.submission_set,
 		sq.status_cd || ': ' || sq.note as queue_status,
 		'Extension/Exemption' as qa_type,
-		'Code ' || tee_wks.extens_exempt_cd as qa_identifier,
+		'Code ' || tee_wks.extens_exempt_cd || 
+		case when tee_wks.mon_sys_id is not null then ' System ID ' || ms.system_identifier when tee_wks.component_id is not null then ' Comp ID ' || c.component_identifier else '' end as qa_identifier,
 		coalesce(sq.user_id , '') as submitter,
 		qa_tee_sq.submission_id as loaded_submission_id,
 		qa_tee_sq.queued_time as loaded_submission_date
@@ -178,6 +185,10 @@ BEGIN
 		and tee.submission_id = qa_tee_sq.submission_id
 	join camdecmpswks.test_extension_exemption tee_wks on
 		sq.test_extension_exemption_id = tee_wks.test_extension_exemption_id
+    left join camdecmpswks.monitor_system ms on
+		tee_wks.mon_sys_id = ms.mon_sys_id
+    left join camdecmpswks.component c on
+		tee_wks.component_id = c.component_id
 	where
 		sq.process_cd = 'QA'
 		and sq.submission_id > coalesce(qa_tee_sq.submission_id, 0)

--- a/deployments/ecmps/release-v2.2/Sprint41/6745/get_submission_audit_data.sql
+++ b/deployments/ecmps/release-v2.2/Sprint41/6745/get_submission_audit_data.sql
@@ -12,7 +12,7 @@ RETURNS TABLE (
     FACILITY_NAME                   CHARACTER VARYING,
     STATE                           CHARACTER VARYING,
     LOCATIONS                       TEXT,
-    PERIOD                          CHARACTER VARYING,
+    PERIOD                          TEXT,
     FILE_TYPE_CD                    CHARACTER VARYING,
     SUBMISSION_ID                   BIGINT,
     SUBMISSION_DATE                 TIMESTAMP,
@@ -26,165 +26,226 @@ RETURNS TABLE (
 ) AS $BODY$
 BEGIN
     RETURN QUERY
-    select
-		vmp.oris_code,
-		vmp.facility_name,
-		vmp.state,
-		vmp.locations,
-		rp.period_abbreviation as period,
-		sq.process_cd as file_type_cd,
-		sq.submission_id,
-		sq.queued_time as submission_date,
-		(
+    with sq_filtered as (
 		select
-			string_agg(sq_sub.submission_id::text, ',')
-		from
-			camdecmpsaux.submission_queue sq_sub
-		where
-			sq_sub.submission_set_id = ss.submission_set_id) as submission_set,
-		sq.status_cd || ': ' || sq.note || case
-			when sq.process_cd = 'EM'
-			and not exists (
-			select
-					pr.pdem_report_id
-			from
-					camdecmpsaux.pdem_report pr
-			where
-					pr.submission_id = sq.submission_id
-				and pr.status_cd = 'COMPLETE')
-			then ' (PDEM missing)'
-	    else ''
-		end as queue_status,
-		case
-			when sq.process_cd = 'QA'
-			and sq.test_sum_id is not null then 'Test'
-			when sq.process_cd = 'QA'
-			and sq.qa_cert_event_id is not null then 'Event'
-			when sq.process_cd = 'QA'
-			and sq.test_extension_exemption_id is not null then 'Extension/Exemption'
-			else null
-		end as qa_type,
-		case
-			when sq.process_cd = 'QA'
-			and sq.test_sum_id is not null then qsd_wks.test_type_cd || ' ' || qsd_wks.test_num
-			when sq.process_cd = 'QA'
-			and sq.qa_cert_event_id is not null then 'Code ' || qce_wks.qa_cert_event_cd || ' Date/Hour ' || to_char(qce_wks.qa_cert_event_date, 'mm/dd/yyyy') || ' ' || qce_wks.qa_cert_event_hour
-			when sq.process_cd = 'QA'
-			and sq.test_extension_exemption_id is not null then 'Code ' || tee_wks.extens_exempt_cd
-			else null
-		end as qa_identifier,
-		coalesce(ss.user_id , '') as submitter,
-		case
-			when sq.process_cd = 'EM' then ee_sq.submission_id
-			when sq.process_cd = 'MP' then mp_sq.submission_id
-			when sq.process_cd = 'QA'
-			and sq.test_sum_id is not null then qa_ts_sq.submission_id
-			when sq.process_cd = 'QA'
-			and sq.qa_cert_event_id is not null then qa_qce_sq.submission_id
-			when sq.process_cd = 'QA'
-			and sq.test_extension_exemption_id is not null then qa_tee_sq.submission_id
-			else null
-		end as loaded_submission_id,
-		case
-			when sq.process_cd = 'EM' then ee_sq.queued_time
-			when sq.process_cd = 'MP' then mp_sq.queued_time
-			when sq.process_cd = 'QA'
-			and sq.test_sum_id is not null then qa_ts_sq.queued_time
-			when sq.process_cd = 'QA'
-			and sq.qa_cert_event_id is not null then qa_qce_sq.queued_time
-			when sq.process_cd = 'QA'
-			and sq.test_extension_exemption_id is not null then qa_tee_sq.queued_time
-			else null
-		end as loaded_submission_date
-	from
-		camdecmpsaux.submission_set ss
-	join camdecmpsaux.submission_queue sq on
-		ss.submission_set_id = sq.submission_set_id
+			sq.process_cd,
+			sq.submission_id,
+			sq.queued_time,
+			sq.status_cd,
+			sq.note,
+			sq.test_sum_id,
+			sq.qa_cert_Event_id,
+			sq.test_extension_exemption_id,
+			sq.submission_set_id,
+			sq.rpt_period_id,
+			ss.mon_plan_id,
+			(select string_agg(sq_sub.submission_id::text, ',')
+			   from	camdecmpsaux.submission_queue sq_sub
+			  where	sq_sub.submission_set_id = ss.submission_set_id) as submission_set,
+			ss.user_id,
+			vmp.oris_code,
+			vmp.facility_name,
+			vmp.state,
+			vmp.locations,
+			mp.submission_id as mp_submission_id
+		from camdecmpsaux.submission_queue sq
+		join camdecmpsaux.submission_set ss on
+			sq.submission_set_id = ss.submission_set_id
+		join camdecmps.vw_monitor_plan vmp on
+			ss.mon_plan_id = vmp.mon_plan_id
+		join camdecmps.monitor_plan mp on
+			vmp.mon_plan_id = mp.mon_plan_id
+		where sq.submission_id > 0
 		and sq.queued_time is not null
 		and (sq.STARTED_TIME is null
 			or sq.COMPLETED_TIME is null
 			or sq.STATUS_CD = 'WIP')
-		AND date_trunc('day', sq.queued_time) BETWEEN COALESCE(v_begin_date, to_date('04/01/2026', 'mm/dd/yyyy')) AND COALESCE(v_end_date, now())
-		AND sq.process_cd = coalesce(v_file_type_cd, sq.process_cd)
-	join camdecmps.vw_monitor_plan vmp on
-		ss.mon_plan_id = vmp.mon_plan_id
-		AND vmp.oris_code = coalesce(v_oris_code, vmp.oris_code)
-		AND vmp.facility_name = coalesce(v_facility_name, vmp.facility_name)
-	join camdecmps.monitor_plan mp on
-		vmp.mon_plan_id = mp.mon_plan_id
-	left join camdecmpsmd.reporting_period rp on
-		sq.rpt_period_id = rp.rpt_period_id
-	left join camdecmps.emission_evaluation ee on
-		ss.mon_plan_id = ee.mon_plan_id
-		and coalesce(sq.rpt_period_id, 0) = ee.rpt_period_id
-	left join camdecmpsaux.submission_queue ee_sq on
-		ee.submission_id = ee_sq.submission_id
+		AND date_trunc('day', sq.queued_time) BETWEEN COALESCE(V_BEGIN_DATE, to_date('04/01/2026', 'mm/dd/yyyy')) AND COALESCE(V_END_DATE, date_trunc('day', now()))
+		AND sq.process_cd = coalesce(V_FILE_TYPE_CD, sq.process_cd)
+		AND vmp.oris_code = coalesce(V_ORIS_CODE, vmp.oris_code)
+		AND vmp.facility_name = coalesce(V_FACILITY_NAME, vmp.facility_name)
+	)
+	select
+		sq.oris_code,
+		sq.facility_name,
+		sq.state,
+		sq.locations,
+		null as period,
+		sq.process_cd as file_type_cd,
+		sq.submission_id,
+		sq.queued_time as submission_date,
+		sq.submission_set,
+		sq.status_cd || ': ' || sq.note as queue_status,
+		null as qa_type,
+		null as qa_identifier,
+		coalesce(sq.user_id , '') as submitter,
+		mp_sq.submission_id as loaded_submission_id,
+		mp_sq.queued_time as loaded_submission_date
+	from
+		sq_filtered sq
 	left join camdecmpsaux.submission_queue mp_sq on
-		mp.submission_id = mp_sq.submission_id
+		mp_sq.process_cd = 'MP'
+		and sq.mp_submission_id = mp_sq.submission_id
+	where
+		sq.process_cd = 'MP'
+		and sq.submission_id > coalesce(mp_sq.submission_id, 0)
+	union all
+	select
+		sq.oris_code,
+		sq.facility_name,
+		sq.state,
+		sq.locations,
+		null as period,
+		sq.process_cd as file_type_cd,
+		sq.submission_id,
+		sq.queued_time as submission_date,
+		sq.submission_set,
+		sq.status_cd || ': ' || sq.note as queue_status,
+		'Test' as qa_type,
+		qsd_wks.test_type_cd || ' ' || qsd_wks.test_num as qa_identifier,
+		coalesce(sq.user_id , '') as submitter,
+		qa_ts_sq.submission_id as loaded_submission_id,
+		qa_ts_sq.queued_time as loaded_submission_date
+	from
+		sq_filtered sq
 	left join camdecmps.qa_supp_data qsd on
 		sq.test_sum_id = qsd.test_sum_id
 	left join camdecmpsaux.submission_queue qa_ts_sq on
-		qsd.submission_id = qa_ts_sq.submission_id
+		qa_ts_sq.process_cd = 'QA'
+		and qa_ts_sq.test_sum_id = qsd.test_sum_id 
+		and qsd.submission_id = qa_ts_sq.submission_id
+	join camdecmpswks.qa_supp_data qsd_wks on
+		sq.test_sum_id = qsd_wks.test_sum_Id
+	where
+		sq.process_cd = 'QA'
+		and sq.submission_id > coalesce(qa_ts_sq.submission_id, 0)
+		and sq.test_sum_id is not null
+	union all
+	select
+		sq.oris_code,
+		sq.facility_name,
+		sq.state,
+		sq.locations,
+		null as period,
+		sq.process_cd as file_type_cd,
+		sq.submission_id,
+		sq.queued_time as submission_date,
+		sq.submission_set,
+		sq.status_cd || ': ' || sq.note as queue_status,
+		'Event' as qa_type,
+		'Code ' || qce_wks.qa_cert_event_cd || ' Date/Hour ' || to_char(qce_wks.qa_cert_event_date, 'mm/dd/yyyy') || ' ' || qce_wks.qa_cert_event_hour as qa_identifier,
+		coalesce(sq.user_id , '') as submitter,
+		qa_qce_sq.submission_id as loaded_submission_id,
+		qa_qce_sq.queued_time as loaded_submission_date
+	from
+		sq_filtered sq
 	left join camdecmps.qa_cert_event qce on
 		sq.qa_cert_event_id = qce.qa_cert_event_id
 	left join camdecmpsaux.submission_queue qa_qce_sq on
-		qce.submission_id = qa_qce_sq.submission_id
+		qa_qce_sq.process_cd = 'QA'
+		and qa_qce_sq.qa_cert_event_id = qce.qa_cert_event_id
+		and qce.submission_id = qa_qce_sq.submission_id
+	join camdecmpswks.qa_cert_event qce_wks on
+		sq.qa_cert_event_id = qce_wks.qa_cert_event_id
+	where
+		sq.process_cd = 'QA'
+		and sq.submission_id > coalesce(qa_qce_sq.submission_id, 0)
+		and sq.qa_cert_event_id is not null
+	union all
+	select
+		sq.oris_code,
+		sq.facility_name,
+		sq.state,
+		sq.locations,
+		null as period,
+		sq.process_cd as file_type_cd,
+		sq.submission_id,
+		sq.queued_time as submission_date,
+		sq.submission_set,
+		sq.status_cd || ': ' || sq.note as queue_status,
+		'Extension/Exemption' as qa_type,
+		'Code ' || tee_wks.extens_exempt_cd as qa_identifier,
+		coalesce(sq.user_id , '') as submitter,
+		qa_tee_sq.submission_id as loaded_submission_id,
+		qa_tee_sq.queued_time as loaded_submission_date
+	from
+		sq_filtered sq
 	left join camdecmps.test_extension_exemption tee on
 		sq.test_extension_exemption_id = tee.test_extension_exemption_id
 	left join camdecmpsaux.submission_queue qa_tee_sq on
-		tee.submission_id = qa_tee_sq.submission_id
-	left join camdecmpswks.qa_supp_data qsd_wks on
-		sq.test_sum_id = qsd_wks.test_sum_Id
-	left join camdecmpswks.qa_cert_event qce_wks on
-		sq.qa_cert_event_id = qce_wks.qa_cert_event_id
-	left join camdecmpswks.test_extension_exemption tee_wks on
+		qa_tee_sq.process_cd = 'QA'
+		and qa_tee_sq.test_extension_exemption_id = tee.test_extension_exemption_id
+		and tee.submission_id = qa_tee_sq.submission_id
+	join camdecmpswks.test_extension_exemption tee_wks on
 		sq.test_extension_exemption_id = tee_wks.test_extension_exemption_id
 	where
-		sq.submission_id > 0
+		sq.process_cd = 'QA'
+		and sq.submission_id > coalesce(qa_tee_sq.submission_id, 0)
+		and sq.test_extension_exemption_id is not null
+	union all
+	select
+		sq.oris_code,
+		sq.facility_name,
+		sq.state,
+		sq.locations,
+		rp.period_abbreviation as period,
+		sq.process_cd as file_type_cd,
+		sq.submission_id,
+		sq.queued_time as submission_date,
+		sq.submission_set,
+		sq.status_cd || ': ' || sq.note || case
+			when not exists (
+			select
+				pr.pdem_report_id
+			from
+				camdecmpsaux.pdem_report pr
+			where
+				pr.mon_plan_id = sq.mon_plan_id 
+				and pr.rpt_period_id = sq.rpt_period_id 
+				and pr.submission_id >= sq.submission_id 
+				and pr.status_cd = 'COMPLETE')
+			then ' (PDEM missing)'
+	    else ''
+		end as queue_status,
+		null as qa_type,
+		null as qa_identifier,
+		coalesce(sq.user_id , '') as submitter,
+		ee_sq.submission_id as loaded_submission_id,
+		ee_sq.queued_time as loaded_submission_date
+	from
+		sq_filtered sq
+	left join camdecmpsmd.reporting_period rp on
+		sq.rpt_period_id = rp.rpt_period_id
+	left join camdecmps.emission_evaluation ee on
+		sq.mon_plan_id = ee.mon_plan_id
+		and coalesce(sq.rpt_period_id, 0) = ee.rpt_period_id
+	left join camdecmpsaux.submission_queue ee_sq on
+		ee_sq.process_cd = 'EM'
+		and ee_sq.rpt_period_id = ee.rpt_period_id 
+		and ee.submission_id = ee_sq.submission_id
+	where
+		sq.process_cd = 'EM'
 		and 
 		(
-			sq.submission_id > coalesce(case
-				when sq.process_cd = 'EM' then ee_sq.submission_id
-				when sq.process_cd = 'MP' then mp_sq.submission_id
-				when sq.process_cd = 'QA' and sq.test_sum_id is not null then qa_ts_sq.submission_id		
-				when sq.process_cd = 'QA' and sq.qa_cert_event_id is not null then qa_qce_sq.submission_id		
-				when sq.process_cd = 'QA' and sq.test_extension_exemption_id is not null then qa_tee_sq.submission_id
-				else null
-			end, 0)
+			sq.submission_id > coalesce(ee_sq.submission_id, 0)
 			or
-			( sq.process_cd = 'EM'
-				and sq.submission_id = ee_sq.submission_id
-				and not exists (
+			not exists (
 				select
 					pr.pdem_report_id
 				from
 					camdecmpsaux.pdem_report pr
 				where
-					pr.submission_id = sq.submission_id
+					pr.mon_plan_id = sq.mon_plan_id 
+					and pr.rpt_period_id = sq.rpt_period_id 
+					and pr.submission_id >= sq.submission_id 
 					and pr.status_cd = 'COMPLETE')
-			)
 		)
-		and (
-			sq.process_cd <> 'QA'
-			or
-			(
-				sq.process_cd = 'QA' 
-				and
-				(
-					(sq.test_sum_id is not null and qsd_wks.test_sum_id is not null)
-					or
-					(sq.qa_cert_event_id is not null and qce_wks.qa_cert_event_id is not null)
-					or
-					(sq.test_extension_exemption_id is not null and tee_wks.test_extension_exemption_id is not null)
-				)
-			)
-		)
-		and sq.note not like '%duplicate key value violates unique constraint%'
-		and sq.note not like '%ENOSPC: no space left on device, mkdir%'
-	order by
-		sq.process_cd,
-		sq.queued_time desc,
-		sq.submission_id;
+	order by 
+		file_type_cd,
+		submission_date desc,
+		submission_id;
+
+
 
 
 END;

--- a/deployments/ecmps/release-v2.2/Sprint41/6745/new_indexes.sql
+++ b/deployments/ecmps/release-v2.2/Sprint41/6745/new_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS idx_submission_queue_completed_time ON camdecmpsaux.submission_queue USING btree (completed_time);
+CREATE INDEX IF NOT EXISTS  idx_submission_queue_started_time ON camdecmpsaux.submission_queue USING btree (started_time);
+CREATE INDEX IF NOT EXISTS  idx_submission_queue_queued_time ON camdecmpsaux.submission_queue ((queued_time::date));


### PR DESCRIPTION
 - rewrite query to properly return only "incomplete" 2.0 submissions
   - submission_queue records where
     - queued_time is not null
     - started_time is null OR completed_time is null OR status_cd = 'WIP' 
     - data has not been subsequently submitted 
     - file type is MP or EM OR file type is QA and the data is still in the workspace
   - for EM, also include records where there is not a completed pdem_report record for the submission_id
 - change v_fac_Id param to v_oris_code