### PR TITLE
#7263 Correcting EM View SP and table scripts.

### DIFF
--- a/camdecmps/procedures/refresh_emission_view_hiappd.sql
+++ b/camdecmps/procedures/refresh_emission_view_hiappd.sql
@@ -16,7 +16,7 @@ BEGIN
             dat.RPT_PERIOD_ID, 
             camdecmps.format_date_hour( dat.BEGIN_DATE, dat.BEGIN_HOUR, null ) AS DATE_HOUR,
             dat.OP_TIME, 
-            dat.SYSTEM_IDENTIFIER AS FUEL_SYS_ID,
+            COALESCE( dat.SYSTEM_IDENTIFIER, '' ) AS FUEL_SYS_ID,
             dat.FUEL_CD AS FUEL_TYPE,
             dat.FUEL_USAGE_TIME AS FUEL_USE_TIME,
             dat.HR_LOAD AS UNIT_LOAD, 

--- a/camdecmps/procedures/refresh_emission_view_noxappesinglefuel.sql
+++ b/camdecmps/procedures/refresh_emission_view_noxappesinglefuel.sql
@@ -41,7 +41,7 @@ BEGIN
             dat.RPT_PERIOD_ID, 
             camdecmps.format_date_hour( dat.BEGIN_DATE, dat.BEGIN_HOUR, null ) as DATE_HOUR,
             dat.OP_TIME, 
-            COALESCE( dat.SYSTEM_IDENTIFIER, '' ) AS FUEL_SYS_ID,
+            COALESCE( dat.FUEL_SYSTEM_IDENTIFIER, '' ) AS FUEL_SYS_ID,
             dat.FUEL_CD as FUEL_TYPE,
             dat.FUEL_USAGE_TIME as FUEL_USE_TIME,
             dat.HR_LOAD as UNIT_LOAD, 

--- a/camdecmps/procedures/refresh_emission_view_noxappesinglefuel.sql
+++ b/camdecmps/procedures/refresh_emission_view_noxappesinglefuel.sql
@@ -41,7 +41,7 @@ BEGIN
             dat.RPT_PERIOD_ID, 
             camdecmps.format_date_hour( dat.BEGIN_DATE, dat.BEGIN_HOUR, null ) as DATE_HOUR,
             dat.OP_TIME, 
-            dat.FUEL_SYSTEM_IDENTIFIER as FUEL_SYS_ID,
+            COALESCE( dat.SYSTEM_IDENTIFIER, '' ) AS FUEL_SYS_ID,
             dat.FUEL_CD as FUEL_TYPE,
             dat.FUEL_USAGE_TIME as FUEL_USE_TIME,
             dat.HR_LOAD as UNIT_LOAD, 

--- a/camdecmps/tables/emission_view_co2appd.sql
+++ b/camdecmps/tables/emission_view_co2appd.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS camdecmps.emission_view_co2appd
     rpt_period_id integer NOT NULL,
     date_hour character varying(25) COLLATE pg_catalog."default" NOT NULL,
     op_time numeric(3,2),
-    fuel_sys_id character varying(3) COLLATE pg_catalog."default",
+    fuel_sys_id character varying(3) COLLATE pg_catalog."default" NOT NULL,
     fuel_type character varying(7) COLLATE pg_catalog."default" NOT NULL,
     fuel_use_time numeric(3,2),
     unit_load numeric(6,0),

--- a/camdecmps/tables/emission_view_co2dailyfuel.sql
+++ b/camdecmps/tables/emission_view_co2dailyfuel.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS camdecmps.emission_view_co2dailyfuel
     rpt_adjusted_daily_co2_mass numeric(10,1),
     rpt_sorbent_rltd_co2_mass numeric(10,1),
     ERROR_CODES character varying(1) COLLATE pg_catalog."default",
-    fuel_cd character varying(7) COLLATE pg_catalog."default",
+    fuel_cd character varying(7) COLLATE pg_catalog."default" NOT NULL,
     daily_fuel_feed numeric(13,1),
     carbon_content_used numeric(5,1),
     fuel_carbon_burned numeric(13,1),

--- a/camdecmps/tables/emission_view_dailycal.sql
+++ b/camdecmps/tables/emission_view_dailycal.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS camdecmps.emission_view_dailycal
     mon_plan_id character varying(45) COLLATE pg_catalog."default" NOT NULL,
     mon_loc_id character varying(45) COLLATE pg_catalog."default" NOT NULL,
     rpt_period_id numeric(38,0) NOT NULL,
-    test_sum_id character varying(45) COLLATE pg_catalog."default",
+    test_sum_id character varying(45) COLLATE pg_catalog."default" NOT NULL,
     component_identifier character varying(3) COLLATE pg_catalog."default",
     component_type_cd character varying(7) COLLATE pg_catalog."default",
     span_scale_cd character varying(7) COLLATE pg_catalog."default",

--- a/camdecmps/tables/emission_view_hiappd.sql
+++ b/camdecmps/tables/emission_view_hiappd.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS camdecmps.emission_view_hiappd
     rpt_period_id integer NOT NULL,
     date_hour character varying(25) COLLATE pg_catalog."default" NOT NULL,
     op_time numeric(3,2),
-    fuel_sys_id character varying(3) COLLATE pg_catalog."default",
+    fuel_sys_id character varying(3) COLLATE pg_catalog."default" NOT NULL,
     fuel_type character varying(7) COLLATE pg_catalog."default" NOT NULL,
     fuel_use_time numeric(3,2),
     unit_load numeric(6,0),

--- a/camdecmps/tables/emission_view_massoilcalc.sql
+++ b/camdecmps/tables/emission_view_massoilcalc.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS camdecmps.emission_view_massoilcalc
     rpt_period_id integer NOT NULL,
     date_hour character varying(25) COLLATE pg_catalog."default" NOT NULL,
     op_time numeric(3,2),
-    fuel_sys_id character varying(3) COLLATE pg_catalog."default",
+    fuel_sys_id character varying(3) COLLATE pg_catalog."default" NOT NULL,
     oil_type character varying(7) COLLATE pg_catalog."default" NOT NULL,
     fuel_use_time numeric(3,2),
     rpt_volumetric_oil_flow numeric(10,1),

--- a/camdecmps/tables/emission_view_noxappesinglefuel.sql
+++ b/camdecmps/tables/emission_view_noxappesinglefuel.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS camdecmps.emission_view_noxappesinglefuel
     rpt_period_id integer NOT NULL,
     date_hour character varying(25) COLLATE pg_catalog."default" NOT NULL,
     op_time numeric(3,2),
-    fuel_sys_id character varying(3) COLLATE pg_catalog."default",
+    fuel_sys_id character varying(3) COLLATE pg_catalog."default" NOT NULL,
     fuel_type character varying(45) COLLATE pg_catalog."default" NOT NULL,
     fuel_use_time numeric(3,2),
     unit_load numeric(6,0),

--- a/camdecmps/tables/emission_view_otherdaily.sql
+++ b/camdecmps/tables/emission_view_otherdaily.sql
@@ -11,5 +11,5 @@ CREATE TABLE IF NOT EXISTS camdecmps.emission_view_otherdaily
     rpt_test_result character varying(7) COLLATE pg_catalog."default" NOT NULL,
     ERROR_CODES character varying(1) COLLATE pg_catalog."default",
     calc_test_result_cd character varying(7) COLLATE pg_catalog."default",
-    test_sum_id character varying(45) COLLATE pg_catalog."default"
+    test_sum_id character varying(45) COLLATE pg_catalog."default" NOT NULL
 ) PARTITION BY RANGE (rpt_period_id);

--- a/camdecmps/tables/emission_view_so2appd.sql
+++ b/camdecmps/tables/emission_view_so2appd.sql
@@ -5,7 +5,7 @@ CREATE TABLE IF NOT EXISTS camdecmps.emission_view_so2appd
     rpt_period_id integer NOT NULL,
     date_hour character varying(25) COLLATE pg_catalog."default" NOT NULL,
     op_time numeric(3,2),
-    fuel_sys_id character varying(3) COLLATE pg_catalog."default",
+    fuel_sys_id character varying(3) COLLATE pg_catalog."default" NOT NULL,
     fuel_type character varying(7) COLLATE pg_catalog."default" NOT NULL,
     fuel_use_time numeric(3,2),
     unit_load numeric(6,0),

--- a/camdecmpswks/procedures/refresh_emission_view_hiappd.sql
+++ b/camdecmpswks/procedures/refresh_emission_view_hiappd.sql
@@ -16,7 +16,7 @@ BEGIN
             dat.RPT_PERIOD_ID, 
             camdecmpswks.format_date_hour( dat.BEGIN_DATE, dat.BEGIN_HOUR, null ) AS DATE_HOUR,
             dat.OP_TIME, 
-            dat.SYSTEM_IDENTIFIER AS FUEL_SYS_ID,
+            COALESCE( dat.SYSTEM_IDENTIFIER, '' ) AS FUEL_SYS_ID,
             dat.FUEL_CD AS FUEL_TYPE,
             dat.FUEL_USAGE_TIME AS FUEL_USE_TIME,
             dat.HR_LOAD AS UNIT_LOAD, 

--- a/camdecmpswks/procedures/refresh_emission_view_noxappesinglefuel.sql
+++ b/camdecmpswks/procedures/refresh_emission_view_noxappesinglefuel.sql
@@ -41,7 +41,7 @@ BEGIN
             dat.RPT_PERIOD_ID, 
             camdecmpswks.format_date_hour( dat.BEGIN_DATE, dat.BEGIN_HOUR, null ) as DATE_HOUR,
             dat.OP_TIME, 
-            COALESCE( dat.SYSTEM_IDENTIFIER, '' ) AS FUEL_SYS_ID,
+            COALESCE( dat.FUEL_SYSTEM_IDENTIFIER, '' ) AS FUEL_SYS_ID,
             dat.FUEL_CD as FUEL_TYPE,
             dat.FUEL_USAGE_TIME as FUEL_USE_TIME,
             dat.HR_LOAD as UNIT_LOAD, 

--- a/camdecmpswks/procedures/refresh_emission_view_noxappesinglefuel.sql
+++ b/camdecmpswks/procedures/refresh_emission_view_noxappesinglefuel.sql
@@ -41,7 +41,7 @@ BEGIN
             dat.RPT_PERIOD_ID, 
             camdecmpswks.format_date_hour( dat.BEGIN_DATE, dat.BEGIN_HOUR, null ) as DATE_HOUR,
             dat.OP_TIME, 
-            dat.FUEL_SYSTEM_IDENTIFIER as FUEL_SYS_ID,
+            COALESCE( dat.SYSTEM_IDENTIFIER, '' ) AS FUEL_SYS_ID,
             dat.FUEL_CD as FUEL_TYPE,
             dat.FUEL_USAGE_TIME as FUEL_USE_TIME,
             dat.HR_LOAD as UNIT_LOAD, 

--- a/deployments/ecmps/release-v2.2/Sprint42/7263/camdecmps/refresh_emission_view_hiappd.sql
+++ b/deployments/ecmps/release-v2.2/Sprint42/7263/camdecmps/refresh_emission_view_hiappd.sql
@@ -1,0 +1,148 @@
+CREATE OR REPLACE PROCEDURE camdecmps.refresh_emission_view_hiappd
+(
+    IN vmonplanid character varying,
+    IN vrptperiodid NUMERIC
+)
+ LANGUAGE plpgsql
+AS $procedure$
+DECLARE
+BEGIN
+
+    RAISE NOTICE 'Deleting existing records...';
+    DELETE FROM camdecmps.EMISSION_VIEW_HIAPPD    WHERE MON_PLAN_ID = vMonPlanId AND RPT_PERIOD_ID = vRptPeriodId;
+    RAISE NOTICE 'Refreshing view data...';
+    INSERT INTO camdecmps.EMISSION_VIEW_HIAPPD(        MON_PLAN_ID,        MON_LOC_ID,        RPT_PERIOD_ID,        DATE_HOUR,        OP_TIME,        FUEL_SYS_ID,        FUEL_TYPE,        FUEL_USE_TIME,        UNIT_LOAD,        LOAD_UOM,        RPT_FUEL_FLOW,        CALC_FUEL_FLOW,        FUEL_FLOW_UOM,        FUEL_FLOW_SODC,        GROSS_CALORIFIC_VALUE,        GCV_UOM,        GCV_SAMPLING_TYPE,        FORMULA_CD,        RPT_HI_RATE,        CALC_HI_RATE,        ERROR_CODES    )    select  dat.MON_PLAN_ID, 
+            dat.MON_LOC_ID, 
+            dat.RPT_PERIOD_ID, 
+            camdecmps.format_date_hour( dat.BEGIN_DATE, dat.BEGIN_HOUR, null ) AS DATE_HOUR,
+            dat.OP_TIME, 
+            COALESCE( dat.SYSTEM_IDENTIFIER, '' ) AS FUEL_SYS_ID,
+            dat.FUEL_CD AS FUEL_TYPE,
+            dat.FUEL_USAGE_TIME AS FUEL_USE_TIME,
+            dat.HR_LOAD AS UNIT_LOAD, 
+            dat.LOAD_UOM_CD AS LOAD_UOM,
+            CASE
+                WHEN ( ( dat.FUEL_GROUP_CD = 'GAS' ) OR ( dat.HI_FORMULA_CD = 'F-19V' ) )
+                THEN dat.VOLUMETRIC_FLOW_RATE
+                ELSE dat.MASS_FLOW_RATE
+            END AS RPT_FUEL_FLOW,
+            CASE
+                WHEN  ( ( dat.FUEL_GROUP_CD = 'GAS' ) OR ( dat.HI_FORMULA_CD = 'F-19V' ) )
+                THEN dat.CALC_VOLUMETRIC_FLOW_RATE
+                ELSE dat.CALC_MASS_FLOW_RATE
+            END AS CALC_FUEL_FLOW,
+            CASE
+                WHEN ( ( dat.FUEL_GROUP_CD = 'GAS') OR (dat.HI_FORMULA_CD = 'F-19V' ) )
+                THEN dat.VOLUMETRIC_UOM_CD
+                ELSE 'LBHR'
+            END AS FUEL_FLOW_UOM,
+            CASE
+                WHEN  ( ( dat.FUEL_GROUP_CD = 'GAS' ) OR ( dat.HI_FORMULA_CD = 'F-19V' ) )
+                THEN dat.SOD_VOLUMETRIC_CD
+                ELSE dat.SOD_MASS_CD
+            END AS FUEL_FLOW_SODC,
+            dat.GCV_PARAM_VAL_FUEL AS GROSS_CALORIFIC_VALUE,
+            dat.GCV_PARAMETER_UOM_CD AS GCV_UOM,
+            dat.GCV_SAMPLE_TYPE_CD AS GCV_SAMPLING_TYPE,
+            dat.HI_FORMULA_CD AS FORMULA_CD,
+            dat.HI_PARAM_VAL_FUEL AS RPT_HI_RATE,
+            dat.HI_CALC_PARAM_VAL_FUEL AS CALC_HI_RATE,
+            (
+                select  case when max( coalesce( sev.SEVERITY_LEVEL, 0 ) ) > 0 then 'Y' else NULL end
+                  from  camdecmpsaux.CHECK_LOG chl
+                        left join camdecmpsmd.SEVERITY_CODE sev
+                          on sev.SEVERITY_CD = chl.SEVERITY_CD
+                 where  chl.CHK_SESSION_ID = dat.CHK_SESSION_ID
+                   and  chl.MON_LOC_ID = dat.MON_LOC_ID
+                   and  ( chl.OP_BEGIN_DATE < dat.BEGIN_DATE or ( chl.OP_BEGIN_DATE = dat.BEGIN_DATE and chl.OP_BEGIN_HOUR <= dat.BEGIN_HOUR ) )
+                   and  ( chl.OP_END_DATE > dat.BEGIN_DATE or ( chl.OP_END_DATE = dat.BEGIN_DATE and chl.OP_END_HOUR >= dat.BEGIN_HOUR ) )
+            ) as error_codes
+      from  (
+                select  hod.HOUR_ID,
+                        mpl.MON_PLAN_ID, 
+                        hod.MON_LOC_ID, 
+                        hod.RPT_PERIOD_ID,
+                        hod.BEGIN_DATE,
+                        hod.BEGIN_HOUR,
+                        hod.OP_TIME,
+                        hod.HR_LOAD,
+                        hod.LOAD_UOM_CD,
+                        ems.CHK_SESSION_ID,
+                        -- HFF
+                        hff.FUEL_CD,
+                        hff.FUEL_USAGE_TIME,
+                        hff.MASS_FLOW_RATE,
+                        hff.CALC_MASS_FLOW_RATE,
+                        hff.VOLUMETRIC_FLOW_RATE,
+                        hff.CALC_VOLUMETRIC_FLOW_RATE,
+                        hff.VOLUMETRIC_UOM_CD,
+                        hff.SOD_MASS_CD,
+                        hff.SOD_VOLUMETRIC_CD,
+                        sys.SYSTEM_IDENTIFIER,
+                        fue.FUEL_GROUP_CD,
+                        -- GCV HPFF
+                        max( case when hpff.PARAMETER_CD = 'GCV' then hpff.PARAM_VAL_FUEL end ) as GCV_PARAM_VAL_FUEL,
+                        max( case when hpff.PARAMETER_CD = 'GCV' then hpff.PARAMETER_UOM_CD end ) as GCV_PARAMETER_UOM_CD,
+                        max( case when hpff.PARAMETER_CD = 'GCV' then hpff.SAMPLE_TYPE_CD end ) as GCV_SAMPLE_TYPE_CD,
+                        -- HI HPFF
+                        max( case when hpff.PARAMETER_CD = 'HI'  then hpff.HRLY_FUEL_FLOW_ID end ) as HI_HRLY_FUEL_FLOW_ID,
+                        max( case when hpff.PARAMETER_CD = 'HI'  then hpff.PARAM_VAL_FUEL end ) as HI_PARAM_VAL_FUEL,
+                        max( case when hpff.PARAMETER_CD = 'HI'  then hpff.CALC_PARAM_VAL_FUEL end ) as HI_CALC_PARAM_VAL_FUEL,
+                        max( case when hpff.PARAMETER_CD = 'HI'  then frm.EQUATION_CD end ) as HI_FORMULA_CD
+                  from  (
+                            select  vmonplanid as MON_PLAN_ID,
+                                    vrptperiodid as RPT_PERIOD_ID
+                        ) sel
+                        join camdecmps.MONITOR_PLAN_LOCATION mpl
+                          on mpl.MON_PLAN_ID = sel.MON_PLAN_ID
+                        join camdecmps.EMISSION_EVALUATION ems
+                          on ems.RPT_PERIOD_ID = sel.RPT_PERIOD_ID
+                         and ems.MON_PLAN_ID = mpl.MON_PLAN_ID
+                        join camdecmps.HRLY_OP_DATA hod 
+                          on hod.rpt_period_id = ems.rpt_period_id
+                         and hod.mon_loc_id = mpl.mon_loc_id
+                        join camdecmps.HRLY_FUEL_FLOW hff
+                          on hff.RPT_PERIOD_ID = hod.RPT_PERIOD_ID
+                         and hff.MON_LOC_ID = hod.MON_LOC_ID
+                         and hff.HOUR_ID = hod.HOUR_ID
+                        left join camdecmps.MONITOR_SYSTEM sys
+                          on sys.MON_SYS_ID = hff.MON_SYS_ID
+                        left join camdecmpsmd.FUEL_CODE fue
+                          on fue.FUEL_CD = hff.FUEL_CD
+                        join camdecmps.HRLY_PARAM_FUEL_FLOW hpff
+                          on hpff.RPT_PERIOD_ID = hff.RPT_PERIOD_ID
+                         and hpff.MON_LOC_ID = hff.MON_LOC_ID
+                         and hpff.HRLY_FUEL_FLOW_ID = hff.HRLY_FUEL_FLOW_ID
+                         and hpff.PARAMETER_CD in ( 'GCV', 'HI' )
+                        left join camdecmps.MONITOR_FORMULA frm
+                          on frm.MON_FORM_ID = hpff.MON_FORM_ID
+                 group
+                    by  hod.HOUR_ID,
+                        mpl.MON_PLAN_ID, 
+                        hod.MON_LOC_ID, 
+                        hod.RPT_PERIOD_ID,
+                        hod.BEGIN_DATE,
+                        hod.BEGIN_HOUR,
+                        hod.OP_TIME,
+                        hod.HR_LOAD,
+                        hod.LOAD_UOM_CD,
+                        ems.CHK_SESSION_ID,
+                        hff.FUEL_CD,
+                        hff.FUEL_USAGE_TIME,
+                        hff.MASS_FLOW_RATE,
+                        hff.CALC_MASS_FLOW_RATE,
+                        hff.VOLUMETRIC_FLOW_RATE,
+                        hff.CALC_VOLUMETRIC_FLOW_RATE,
+                        hff.VOLUMETRIC_UOM_CD,
+                        hff.SOD_MASS_CD,
+                        hff.SOD_VOLUMETRIC_CD,
+                        sys.SYSTEM_IDENTIFIER,
+                        fue.FUEL_GROUP_CD
+            ) dat
+     where  dat.HI_HRLY_FUEL_FLOW_ID is not null;
+
+    RAISE NOTICE 'Refreshing view counts...';
+    CALL camdecmps.refresh_emission_view_count(vmonplanid, vrptperiodid, 'HIAPPD');
+    RAISE NOTICE 'Refresh complete @ % %', CURRENT_DATE, CURRENT_TIME;
+END
+$procedure$

--- a/deployments/ecmps/release-v2.2/Sprint42/7263/camdecmps/refresh_emission_view_noxappesinglefuel.sql
+++ b/deployments/ecmps/release-v2.2/Sprint42/7263/camdecmps/refresh_emission_view_noxappesinglefuel.sql
@@ -1,0 +1,161 @@
+CREATE OR REPLACE PROCEDURE camdecmps.refresh_emission_view_noxappesinglefuel
+(
+    IN vmonplanid character varying,
+    IN vrptperiodid NUMERIC
+)
+ LANGUAGE plpgsql
+AS $procedure$
+declare 
+BEGIN
+    RAISE NOTICE 'Deleting existing records...';
+	DELETE FROM camdecmps.EMISSION_VIEW_NOXAPPESINGLEFUEL	WHERE MON_PLAN_ID = vMonPlanId AND RPT_PERIOD_ID = vRptPeriodId;
+    RAISE NOTICE 'Refreshing view data...';
+	INSERT INTO camdecmps.EMISSION_VIEW_NOXAPPESINGLEFUEL(
+		MON_PLAN_ID,
+		MON_LOC_ID,
+		RPT_PERIOD_ID,
+		DATE_HOUR,
+		OP_TIME,
+		FUEL_SYS_ID,
+		FUEL_TYPE,
+		FUEL_USE_TIME,
+		UNIT_LOAD,
+		LOAD_UOM,
+		CALC_HI_RATE,
+		OPERATING_CONDITION_CD,
+		SEGMENT_NUMBER,
+		APP_E_SYS_ID,
+		RPT_NOX_EMISSION_RATE,
+		CALC_NOX_EMISSION_RATE,
+		SUMMATION_FORMULA_CD,
+		RPT_NOX_EMISSION_RATE_ALL_FUELS,
+		CALC_NOX_EMISSION_RATE_ALL_FUELS,
+		CALC_HI_RATE_ALL_FUELS,
+		NOX_MASS_RATE_FORMULA_CD,
+		RPT_NOX_MASS_ALL_FUELS,
+		CALC_NOX_MASS_ALL_FUELS,
+		ERROR_CODES
+	)
+    select  dat.MON_PLAN_ID, 
+            dat.MON_LOC_ID, 
+            dat.RPT_PERIOD_ID, 
+            camdecmps.format_date_hour( dat.BEGIN_DATE, dat.BEGIN_HOUR, null ) as DATE_HOUR,
+            dat.OP_TIME, 
+            COALESCE( dat.FUEL_SYSTEM_IDENTIFIER, '' ) AS FUEL_SYS_ID,
+            dat.FUEL_CD as FUEL_TYPE,
+            dat.FUEL_USAGE_TIME as FUEL_USE_TIME,
+            dat.HR_LOAD as UNIT_LOAD, 
+            dat.LOAD_UOM_CD as LOAD_UOM,
+            dat.HI_CALC_PARAM_VAL_FUEL as CALC_HI_RATE,
+            dat.NOXR_OPERATING_CONDITION_CD,
+            dat.NOXR_SEGMENT_NUM as SEGMENT_NUMBER,
+            dat.NOXR_APPE_SYSTEM_IDENTIFIER as APP_E_SYS_ID,
+            dat.NOXR_PARAM_VAL_FUEL as RPT_NOX_EMISSION_RATE,
+            dat.NOXR_CALC_PARAM_VAL_FUEL as CALC_NOX_EMISSION_RATE,
+            dat.NOXR_FORMULA_CD as SUMMATION_FORMULA_CD,
+            dat.NOXR_ADJUSTED_HRLY_VALUE as RPT_NOX_EMISSION_RATE_ALL_FUELS,
+            dat.NOXR_CALC_ADJUSTED_HRLY_VALUE as CALC_NOX_EMISSION_RATE_ALL_FUELS,
+            case 
+                when ( dat.NOX_HOUR_ID is not null )
+                then dat.HI_CALC_ADJUSTED_HRLY_VALUE
+            end as CALC_HI_RATE_ALL_FUELS,
+            dat.NOX_FORMULA_CD as NOX_MASS_RATE_FORMULA_CD,
+            dat.NOX_ADJUSTED_HRLY_VALUE as RPT_NOX_MASS_ALL_FUELS,
+            dat.NOX_CALC_ADJUSTED_HRLY_VALUE as CALC_NOX_MASS_ALL_FUELS,
+            (
+                select  case when max( coalesce( sev.SEVERITY_LEVEL, 0 ) ) > 0 then 'Y' else NULL end
+                  from  camdecmpsaux.CHECK_LOG chl
+                        left join camdecmpsmd.SEVERITY_CODE sev
+                          on sev.SEVERITY_CD = chl.SEVERITY_CD
+                 where  chl.CHK_SESSION_ID = dat.CHK_SESSION_ID
+                   and  chl.MON_LOC_ID = dat.MON_LOC_ID
+                   and  ( chl.OP_BEGIN_DATE < dat.BEGIN_DATE or ( chl.OP_BEGIN_DATE = dat.BEGIN_DATE and chl.OP_BEGIN_HOUR <= dat.BEGIN_HOUR ) )
+                   and  ( chl.OP_END_DATE > dat.BEGIN_DATE or ( chl.OP_END_DATE = dat.BEGIN_DATE and chl.OP_END_HOUR >= dat.BEGIN_HOUR ) )
+            ) as error_codes
+      from  (
+                select  mpl.MON_PLAN_ID, 
+                        hod.MON_LOC_ID, 
+                        hod.RPT_PERIOD_ID,
+                        hod.BEGIN_DATE,
+                        hod.BEGIN_HOUR,
+                        hod.OP_TIME,
+                        hod.HR_LOAD,
+                        hod.LOAD_UOM_CD,
+                        -- HFF
+                        hff.FUEL_CD,
+                        hff.FUEL_USAGE_TIME,
+                        sys_hff.SYSTEM_IDENTIFIER as FUEL_SYSTEM_IDENTIFIER,
+                        -- HI HPFF
+                        max( case when hpff.PARAMETER_CD = 'HI'   then hpff.CALC_PARAM_VAL_FUEL end ) as HI_CALC_PARAM_VAL_FUEL,
+                        -- NOXR HPFF
+                        max( case when hpff.PARAMETER_CD = 'NOXR' then hpff.HRLY_FUEL_FLOW_ID end ) as NOXR_HRLY_FUEL_FLOW_ID,
+                        max( case when hpff.PARAMETER_CD = 'NOXR' then hpff.PARAM_VAL_FUEL end ) as NOXR_PARAM_VAL_FUEL,
+                        max( case when hpff.PARAMETER_CD = 'NOXR' then hpff.CALC_PARAM_VAL_FUEL end ) as NOXR_CALC_PARAM_VAL_FUEL,
+                        max( case when hpff.PARAMETER_CD = 'NOXR' then hpff.OPERATING_CONDITION_CD end ) as NOXR_OPERATING_CONDITION_CD,
+                        max( case when hpff.PARAMETER_CD = 'NOXR' then hpff.SEGMENT_NUM end ) as NOXR_SEGMENT_NUM,
+                        max( case when hpff.PARAMETER_CD = 'NOXR' then sys_hpff.SYSTEM_IDENTIFIER end ) as NOXR_APPE_SYSTEM_IDENTIFIER,
+                        -- HI DHV
+                        max( case when dhv.PARAMETER_CD  = 'HI'   then dhv.CALC_ADJUSTED_HRLY_VALUE end ) as HI_CALC_ADJUSTED_HRLY_VALUE,
+                        -- NOX DHV
+                        max( case when dhv.PARAMETER_CD  = 'NOX'  then dhv.HOUR_ID end ) as NOX_HOUR_ID,
+                        max( case when dhv.PARAMETER_CD  = 'NOX'  then dhv.ADJUSTED_HRLY_VALUE end ) as NOX_ADJUSTED_HRLY_VALUE,
+                        max( case when dhv.PARAMETER_CD  = 'NOX'  then dhv.CALC_ADJUSTED_HRLY_VALUE end ) as NOX_CALC_ADJUSTED_HRLY_VALUE,
+                        max( case when dhv.PARAMETER_CD  = 'NOX'  then frm.EQUATION_CD end ) as NOX_FORMULA_CD,
+                        -- NOXR DHV
+                        max( case when dhv.PARAMETER_CD  = 'NOXR' then dhv.ADJUSTED_HRLY_VALUE end ) as NOXR_ADJUSTED_HRLY_VALUE,
+                        max( case when dhv.PARAMETER_CD  = 'NOXR' then dhv.CALC_ADJUSTED_HRLY_VALUE end ) as NOXR_CALC_ADJUSTED_HRLY_VALUE,
+                        max( case when dhv.PARAMETER_CD  = 'NOXR' then frm.EQUATION_CD end ) as NOXR_FORMULA_CD,
+                        -- Error Information
+                        ems.CHK_SESSION_ID
+                  from  (
+                            select  vmonplanid as MON_PLAN_ID,
+                                    vrptperiodid as RPT_PERIOD_ID
+                        ) sel
+                        join camdecmps.MONITOR_PLAN_LOCATION mpl
+                          on mpl.MON_PLAN_ID = sel.MON_PLAN_ID
+                        join camdecmps.EMISSION_EVALUATION ems
+                          on ems.RPT_PERIOD_ID = sel.RPT_PERIOD_ID
+                         and ems.MON_PLAN_ID = mpl.MON_PLAN_ID
+                        join camdecmps.HRLY_OP_DATA hod 
+                          on hod.rpt_period_id = ems.rpt_period_id
+                         and hod.mon_loc_id = mpl.mon_loc_id
+                        join camdecmps.HRLY_FUEL_FLOW hff
+                          on hff.RPT_PERIOD_ID = hod.RPT_PERIOD_ID
+                         and hff.MON_LOC_ID = hod.MON_LOC_ID
+                         and hff.HOUR_ID = hod.HOUR_ID
+                        left join camdecmps.MONITOR_SYSTEM sys_hff
+                          on sys_hff.MON_SYS_ID = hff.MON_SYS_ID
+                        join camdecmps.HRLY_PARAM_FUEL_FLOW hpff
+                          on hpff.RPT_PERIOD_ID = hff.RPT_PERIOD_ID
+                         and hpff.MON_LOC_ID = hff.MON_LOC_ID
+                         and hpff.HRLY_FUEL_FLOW_ID = hff.HRLY_FUEL_FLOW_ID
+                         and hpff.PARAMETER_CD in ( 'HI', 'NOXR' )
+                        left join camdecmps.MONITOR_SYSTEM sys_hpff
+                          on sys_hpff.MON_SYS_ID = hpff.MON_SYS_ID
+                        left join camdecmps.DERIVED_HRLY_VALUE dhv
+                          on dhv.RPT_PERIOD_ID = hod.RPT_PERIOD_ID
+                         and dhv.MON_LOC_ID = hod.MON_LOC_ID
+                         and dhv.HOUR_ID = hod.HOUR_ID
+                         and dhv.PARAMETER_CD in ( 'HI', 'NOX', 'NOXR' )
+                        left join camdecmps.MONITOR_FORMULA frm
+                          on frm.MON_FORM_ID = dhv.MON_FORM_ID
+                 group
+                    by  mpl.MON_PLAN_ID, 
+                        hod.MON_LOC_ID, 
+                        hod.RPT_PERIOD_ID,
+                        hod.BEGIN_DATE,
+                        hod.BEGIN_HOUR,
+                        hod.OP_TIME,
+                        hod.HR_LOAD,
+                        hod.LOAD_UOM_CD,
+                        hff.FUEL_CD,
+                        hff.FUEL_USAGE_TIME,
+                        sys_hff.SYSTEM_IDENTIFIER,
+                        ems.CHK_SESSION_ID
+            ) dat
+     where  dat.NOXR_HRLY_FUEL_FLOW_ID is not null;
+
+    RAISE NOTICE 'Refreshing view counts...';
+    CALL camdecmps.refresh_emission_view_count(vmonplanid, vrptperiodid, 'NOXAPPESINGLEFUEL');
+END
+$procedure$

--- a/deployments/ecmps/release-v2.2/Sprint42/7263/camdecmpswks/refresh_emission_view_hiappd.sql
+++ b/deployments/ecmps/release-v2.2/Sprint42/7263/camdecmpswks/refresh_emission_view_hiappd.sql
@@ -1,0 +1,148 @@
+CREATE OR REPLACE PROCEDURE camdecmpswks.refresh_emission_view_hiappd
+(
+    IN vmonplanid character varying,
+    IN vrptperiodid NUMERIC
+)
+ LANGUAGE plpgsql
+AS $procedure$
+DECLARE
+BEGIN
+
+    RAISE NOTICE 'Deleting existing records...';
+    DELETE FROM camdecmpswks.EMISSION_VIEW_HIAPPD    WHERE MON_PLAN_ID = vMonPlanId AND RPT_PERIOD_ID = vRptPeriodId;
+    RAISE NOTICE 'Refreshing view data...';
+    INSERT INTO camdecmpswks.EMISSION_VIEW_HIAPPD(        MON_PLAN_ID,        MON_LOC_ID,        RPT_PERIOD_ID,        DATE_HOUR,        OP_TIME,        FUEL_SYS_ID,        FUEL_TYPE,        FUEL_USE_TIME,        UNIT_LOAD,        LOAD_UOM,        RPT_FUEL_FLOW,        CALC_FUEL_FLOW,        FUEL_FLOW_UOM,        FUEL_FLOW_SODC,        GROSS_CALORIFIC_VALUE,        GCV_UOM,        GCV_SAMPLING_TYPE,        FORMULA_CD,        RPT_HI_RATE,        CALC_HI_RATE,        ERROR_CODES    )    select  dat.MON_PLAN_ID, 
+            dat.MON_LOC_ID, 
+            dat.RPT_PERIOD_ID, 
+            camdecmpswks.format_date_hour( dat.BEGIN_DATE, dat.BEGIN_HOUR, null ) AS DATE_HOUR,
+            dat.OP_TIME, 
+            COALESCE( dat.SYSTEM_IDENTIFIER, '' ) AS FUEL_SYS_ID,
+            dat.FUEL_CD AS FUEL_TYPE,
+            dat.FUEL_USAGE_TIME AS FUEL_USE_TIME,
+            dat.HR_LOAD AS UNIT_LOAD, 
+            dat.LOAD_UOM_CD AS LOAD_UOM,
+            CASE
+                WHEN ( ( dat.FUEL_GROUP_CD = 'GAS' ) OR ( dat.HI_FORMULA_CD = 'F-19V' ) )
+                THEN dat.VOLUMETRIC_FLOW_RATE
+                ELSE dat.MASS_FLOW_RATE
+            END AS RPT_FUEL_FLOW,
+            CASE
+                WHEN  ( ( dat.FUEL_GROUP_CD = 'GAS' ) OR ( dat.HI_FORMULA_CD = 'F-19V' ) )
+                THEN dat.CALC_VOLUMETRIC_FLOW_RATE
+                ELSE dat.CALC_MASS_FLOW_RATE
+            END AS CALC_FUEL_FLOW,
+            CASE
+                WHEN ( ( dat.FUEL_GROUP_CD = 'GAS') OR (dat.HI_FORMULA_CD = 'F-19V' ) )
+                THEN dat.VOLUMETRIC_UOM_CD
+                ELSE 'LBHR'
+            END AS FUEL_FLOW_UOM,
+            CASE
+                WHEN  ( ( dat.FUEL_GROUP_CD = 'GAS' ) OR ( dat.HI_FORMULA_CD = 'F-19V' ) )
+                THEN dat.SOD_VOLUMETRIC_CD
+                ELSE dat.SOD_MASS_CD
+            END AS FUEL_FLOW_SODC,
+            dat.GCV_PARAM_VAL_FUEL AS GROSS_CALORIFIC_VALUE,
+            dat.GCV_PARAMETER_UOM_CD AS GCV_UOM,
+            dat.GCV_SAMPLE_TYPE_CD AS GCV_SAMPLING_TYPE,
+            dat.HI_FORMULA_CD AS FORMULA_CD,
+            dat.HI_PARAM_VAL_FUEL AS RPT_HI_RATE,
+            dat.HI_CALC_PARAM_VAL_FUEL AS CALC_HI_RATE,
+            (
+                select  case when max( coalesce( sev.SEVERITY_LEVEL, 0 ) ) > 0 then 'Y' else NULL end
+                  from  camdecmpswks.CHECK_LOG chl
+                        left join camdecmpsmd.SEVERITY_CODE sev
+                          on sev.SEVERITY_CD = chl.SEVERITY_CD
+                 where  chl.CHK_SESSION_ID = dat.CHK_SESSION_ID
+                   and  chl.MON_LOC_ID = dat.MON_LOC_ID
+                   and  ( chl.OP_BEGIN_DATE < dat.BEGIN_DATE or ( chl.OP_BEGIN_DATE = dat.BEGIN_DATE and chl.OP_BEGIN_HOUR <= dat.BEGIN_HOUR ) )
+                   and  ( chl.OP_END_DATE > dat.BEGIN_DATE or ( chl.OP_END_DATE = dat.BEGIN_DATE and chl.OP_END_HOUR >= dat.BEGIN_HOUR ) )
+            ) as error_codes
+      from  (
+                select  hod.HOUR_ID,
+                        mpl.MON_PLAN_ID, 
+                        hod.MON_LOC_ID, 
+                        hod.RPT_PERIOD_ID,
+                        hod.BEGIN_DATE,
+                        hod.BEGIN_HOUR,
+                        hod.OP_TIME,
+                        hod.HR_LOAD,
+                        hod.LOAD_UOM_CD,
+                        ems.CHK_SESSION_ID,
+                        -- HFF
+                        hff.FUEL_CD,
+                        hff.FUEL_USAGE_TIME,
+                        hff.MASS_FLOW_RATE,
+                        hff.CALC_MASS_FLOW_RATE,
+                        hff.VOLUMETRIC_FLOW_RATE,
+                        hff.CALC_VOLUMETRIC_FLOW_RATE,
+                        hff.VOLUMETRIC_UOM_CD,
+                        hff.SOD_MASS_CD,
+                        hff.SOD_VOLUMETRIC_CD,
+                        sys.SYSTEM_IDENTIFIER,
+                        fue.FUEL_GROUP_CD,
+                        -- GCV HPFF
+                        max( case when hpff.PARAMETER_CD = 'GCV' then hpff.PARAM_VAL_FUEL end ) as GCV_PARAM_VAL_FUEL,
+                        max( case when hpff.PARAMETER_CD = 'GCV' then hpff.PARAMETER_UOM_CD end ) as GCV_PARAMETER_UOM_CD,
+                        max( case when hpff.PARAMETER_CD = 'GCV' then hpff.SAMPLE_TYPE_CD end ) as GCV_SAMPLE_TYPE_CD,
+                        -- HI HPFF
+                        max( case when hpff.PARAMETER_CD = 'HI'  then hpff.HRLY_FUEL_FLOW_ID end ) as HI_HRLY_FUEL_FLOW_ID,
+                        max( case when hpff.PARAMETER_CD = 'HI'  then hpff.PARAM_VAL_FUEL end ) as HI_PARAM_VAL_FUEL,
+                        max( case when hpff.PARAMETER_CD = 'HI'  then hpff.CALC_PARAM_VAL_FUEL end ) as HI_CALC_PARAM_VAL_FUEL,
+                        max( case when hpff.PARAMETER_CD = 'HI'  then frm.EQUATION_CD end ) as HI_FORMULA_CD
+                  from  (
+                            select  vmonplanid as MON_PLAN_ID,
+                                    vrptperiodid as RPT_PERIOD_ID
+                        ) sel
+                        join camdecmpswks.MONITOR_PLAN_LOCATION mpl
+                          on mpl.MON_PLAN_ID = sel.MON_PLAN_ID
+                        join camdecmpswks.EMISSION_EVALUATION ems
+                          on ems.RPT_PERIOD_ID = sel.RPT_PERIOD_ID
+                         and ems.MON_PLAN_ID = mpl.MON_PLAN_ID
+                        join camdecmpswks.HRLY_OP_DATA hod 
+                          on hod.rpt_period_id = ems.rpt_period_id
+                         and hod.mon_loc_id = mpl.mon_loc_id
+                        join camdecmpswks.HRLY_FUEL_FLOW hff
+                          on hff.RPT_PERIOD_ID = hod.RPT_PERIOD_ID
+                         and hff.MON_LOC_ID = hod.MON_LOC_ID
+                         and hff.HOUR_ID = hod.HOUR_ID
+                        left join camdecmpswks.MONITOR_SYSTEM sys
+                          on sys.MON_SYS_ID = hff.MON_SYS_ID
+                        left join camdecmpsmd.FUEL_CODE fue
+                          on fue.FUEL_CD = hff.FUEL_CD
+                        join camdecmpswks.HRLY_PARAM_FUEL_FLOW hpff
+                          on hpff.RPT_PERIOD_ID = hff.RPT_PERIOD_ID
+                         and hpff.MON_LOC_ID = hff.MON_LOC_ID
+                         and hpff.HRLY_FUEL_FLOW_ID = hff.HRLY_FUEL_FLOW_ID
+                         and hpff.PARAMETER_CD in ( 'GCV', 'HI' )
+                        left join camdecmpswks.MONITOR_FORMULA frm
+                          on frm.MON_FORM_ID = hpff.MON_FORM_ID
+                 group
+                    by  hod.HOUR_ID,
+                        mpl.MON_PLAN_ID, 
+                        hod.MON_LOC_ID, 
+                        hod.RPT_PERIOD_ID,
+                        hod.BEGIN_DATE,
+                        hod.BEGIN_HOUR,
+                        hod.OP_TIME,
+                        hod.HR_LOAD,
+                        hod.LOAD_UOM_CD,
+                        ems.CHK_SESSION_ID,
+                        hff.FUEL_CD,
+                        hff.FUEL_USAGE_TIME,
+                        hff.MASS_FLOW_RATE,
+                        hff.CALC_MASS_FLOW_RATE,
+                        hff.VOLUMETRIC_FLOW_RATE,
+                        hff.CALC_VOLUMETRIC_FLOW_RATE,
+                        hff.VOLUMETRIC_UOM_CD,
+                        hff.SOD_MASS_CD,
+                        hff.SOD_VOLUMETRIC_CD,
+                        sys.SYSTEM_IDENTIFIER,
+                        fue.FUEL_GROUP_CD
+            ) dat
+     where  dat.HI_HRLY_FUEL_FLOW_ID is not null;
+
+    RAISE NOTICE 'Refreshing view counts...';
+    CALL camdecmpswks.refresh_emission_view_count(vmonplanid, vrptperiodid, 'HIAPPD');
+    RAISE NOTICE 'Refresh complete @ % %', CURRENT_DATE, CURRENT_TIME;
+END
+$procedure$

--- a/deployments/ecmps/release-v2.2/Sprint42/7263/camdecmpswks/refresh_emission_view_noxappesinglefuel.sql
+++ b/deployments/ecmps/release-v2.2/Sprint42/7263/camdecmpswks/refresh_emission_view_noxappesinglefuel.sql
@@ -1,0 +1,161 @@
+CREATE OR REPLACE PROCEDURE camdecmpswks.refresh_emission_view_noxappesinglefuel
+(
+    IN vmonplanid character varying,
+    IN vrptperiodid NUMERIC
+)
+ LANGUAGE plpgsql
+AS $procedure$
+declare 
+BEGIN
+    RAISE NOTICE 'Deleting existing records...';
+	DELETE FROM camdecmpswks.EMISSION_VIEW_NOXAPPESINGLEFUEL	WHERE MON_PLAN_ID = vMonPlanId AND RPT_PERIOD_ID = vRptPeriodId;
+    RAISE NOTICE 'Refreshing view data...';
+	INSERT INTO camdecmpswks.EMISSION_VIEW_NOXAPPESINGLEFUEL(
+		MON_PLAN_ID,
+		MON_LOC_ID,
+		RPT_PERIOD_ID,
+		DATE_HOUR,
+		OP_TIME,
+		FUEL_SYS_ID,
+		FUEL_TYPE,
+		FUEL_USE_TIME,
+		UNIT_LOAD,
+		LOAD_UOM,
+		CALC_HI_RATE,
+		OPERATING_CONDITION_CD,
+		SEGMENT_NUMBER,
+		APP_E_SYS_ID,
+		RPT_NOX_EMISSION_RATE,
+		CALC_NOX_EMISSION_RATE,
+		SUMMATION_FORMULA_CD,
+		RPT_NOX_EMISSION_RATE_ALL_FUELS,
+		CALC_NOX_EMISSION_RATE_ALL_FUELS,
+		CALC_HI_RATE_ALL_FUELS,
+		NOX_MASS_RATE_FORMULA_CD,
+		RPT_NOX_MASS_ALL_FUELS,
+		CALC_NOX_MASS_ALL_FUELS,
+		ERROR_CODES
+	)
+    select  dat.MON_PLAN_ID, 
+            dat.MON_LOC_ID, 
+            dat.RPT_PERIOD_ID, 
+            camdecmpswks.format_date_hour( dat.BEGIN_DATE, dat.BEGIN_HOUR, null ) as DATE_HOUR,
+            dat.OP_TIME, 
+            COALESCE( dat.FUEL_SYSTEM_IDENTIFIER, '' ) AS FUEL_SYS_ID,
+            dat.FUEL_CD as FUEL_TYPE,
+            dat.FUEL_USAGE_TIME as FUEL_USE_TIME,
+            dat.HR_LOAD as UNIT_LOAD, 
+            dat.LOAD_UOM_CD as LOAD_UOM,
+            dat.HI_CALC_PARAM_VAL_FUEL as CALC_HI_RATE,
+            dat.NOXR_OPERATING_CONDITION_CD,
+            dat.NOXR_SEGMENT_NUM as SEGMENT_NUMBER,
+            dat.NOXR_APPE_SYSTEM_IDENTIFIER as APP_E_SYS_ID,
+            dat.NOXR_PARAM_VAL_FUEL as RPT_NOX_EMISSION_RATE,
+            dat.NOXR_CALC_PARAM_VAL_FUEL as CALC_NOX_EMISSION_RATE,
+            dat.NOXR_FORMULA_CD as SUMMATION_FORMULA_CD,
+            dat.NOXR_ADJUSTED_HRLY_VALUE as RPT_NOX_EMISSION_RATE_ALL_FUELS,
+            dat.NOXR_CALC_ADJUSTED_HRLY_VALUE as CALC_NOX_EMISSION_RATE_ALL_FUELS,
+            case 
+                when ( dat.NOX_HOUR_ID is not null )
+                then dat.HI_CALC_ADJUSTED_HRLY_VALUE
+            end as CALC_HI_RATE_ALL_FUELS,
+            dat.NOX_FORMULA_CD as NOX_MASS_RATE_FORMULA_CD,
+            dat.NOX_ADJUSTED_HRLY_VALUE as RPT_NOX_MASS_ALL_FUELS,
+            dat.NOX_CALC_ADJUSTED_HRLY_VALUE as CALC_NOX_MASS_ALL_FUELS,
+            (
+                select  case when max( coalesce( sev.SEVERITY_LEVEL, 0 ) ) > 0 then 'Y' else NULL end
+                  from  camdecmpswks.CHECK_LOG chl
+                        left join camdecmpsmd.SEVERITY_CODE sev
+                          on sev.SEVERITY_CD = chl.SEVERITY_CD
+                 where  chl.CHK_SESSION_ID = dat.CHK_SESSION_ID
+                   and  chl.MON_LOC_ID = dat.MON_LOC_ID
+                   and  ( chl.OP_BEGIN_DATE < dat.BEGIN_DATE or ( chl.OP_BEGIN_DATE = dat.BEGIN_DATE and chl.OP_BEGIN_HOUR <= dat.BEGIN_HOUR ) )
+                   and  ( chl.OP_END_DATE > dat.BEGIN_DATE or ( chl.OP_END_DATE = dat.BEGIN_DATE and chl.OP_END_HOUR >= dat.BEGIN_HOUR ) )
+            ) as error_codes
+      from  (
+                select  mpl.MON_PLAN_ID, 
+                        hod.MON_LOC_ID, 
+                        hod.RPT_PERIOD_ID,
+                        hod.BEGIN_DATE,
+                        hod.BEGIN_HOUR,
+                        hod.OP_TIME,
+                        hod.HR_LOAD,
+                        hod.LOAD_UOM_CD,
+                        -- HFF
+                        hff.FUEL_CD,
+                        hff.FUEL_USAGE_TIME,
+                        sys_hff.SYSTEM_IDENTIFIER as FUEL_SYSTEM_IDENTIFIER,
+                        -- HI HPFF
+                        max( case when hpff.PARAMETER_CD = 'HI'   then hpff.CALC_PARAM_VAL_FUEL end ) as HI_CALC_PARAM_VAL_FUEL,
+                        -- NOXR HPFF
+                        max( case when hpff.PARAMETER_CD = 'NOXR' then hpff.HRLY_FUEL_FLOW_ID end ) as NOXR_HRLY_FUEL_FLOW_ID,
+                        max( case when hpff.PARAMETER_CD = 'NOXR' then hpff.PARAM_VAL_FUEL end ) as NOXR_PARAM_VAL_FUEL,
+                        max( case when hpff.PARAMETER_CD = 'NOXR' then hpff.CALC_PARAM_VAL_FUEL end ) as NOXR_CALC_PARAM_VAL_FUEL,
+                        max( case when hpff.PARAMETER_CD = 'NOXR' then hpff.OPERATING_CONDITION_CD end ) as NOXR_OPERATING_CONDITION_CD,
+                        max( case when hpff.PARAMETER_CD = 'NOXR' then hpff.SEGMENT_NUM end ) as NOXR_SEGMENT_NUM,
+                        max( case when hpff.PARAMETER_CD = 'NOXR' then sys_hpff.SYSTEM_IDENTIFIER end ) as NOXR_APPE_SYSTEM_IDENTIFIER,
+                        -- HI DHV
+                        max( case when dhv.PARAMETER_CD  = 'HI'   then dhv.CALC_ADJUSTED_HRLY_VALUE end ) as HI_CALC_ADJUSTED_HRLY_VALUE,
+                        -- NOX DHV
+                        max( case when dhv.PARAMETER_CD  = 'NOX'  then dhv.HOUR_ID end ) as NOX_HOUR_ID,
+                        max( case when dhv.PARAMETER_CD  = 'NOX'  then dhv.ADJUSTED_HRLY_VALUE end ) as NOX_ADJUSTED_HRLY_VALUE,
+                        max( case when dhv.PARAMETER_CD  = 'NOX'  then dhv.CALC_ADJUSTED_HRLY_VALUE end ) as NOX_CALC_ADJUSTED_HRLY_VALUE,
+                        max( case when dhv.PARAMETER_CD  = 'NOX'  then frm.EQUATION_CD end ) as NOX_FORMULA_CD,
+                        -- NOXR DHV
+                        max( case when dhv.PARAMETER_CD  = 'NOXR' then dhv.ADJUSTED_HRLY_VALUE end ) as NOXR_ADJUSTED_HRLY_VALUE,
+                        max( case when dhv.PARAMETER_CD  = 'NOXR' then dhv.CALC_ADJUSTED_HRLY_VALUE end ) as NOXR_CALC_ADJUSTED_HRLY_VALUE,
+                        max( case when dhv.PARAMETER_CD  = 'NOXR' then frm.EQUATION_CD end ) as NOXR_FORMULA_CD,
+                        -- Error Information
+                        ems.CHK_SESSION_ID
+                  from  (
+                            select  vmonplanid as MON_PLAN_ID,
+                                    vrptperiodid as RPT_PERIOD_ID
+                        ) sel
+                        join camdecmpswks.MONITOR_PLAN_LOCATION mpl
+                          on mpl.MON_PLAN_ID = sel.MON_PLAN_ID
+                        join camdecmpswks.EMISSION_EVALUATION ems
+                          on ems.RPT_PERIOD_ID = sel.RPT_PERIOD_ID
+                         and ems.MON_PLAN_ID = mpl.MON_PLAN_ID
+                        join camdecmpswks.HRLY_OP_DATA hod 
+                          on hod.rpt_period_id = ems.rpt_period_id
+                         and hod.mon_loc_id = mpl.mon_loc_id
+                        join camdecmpswks.HRLY_FUEL_FLOW hff
+                          on hff.RPT_PERIOD_ID = hod.RPT_PERIOD_ID
+                         and hff.MON_LOC_ID = hod.MON_LOC_ID
+                         and hff.HOUR_ID = hod.HOUR_ID
+                        left join camdecmpswks.MONITOR_SYSTEM sys_hff
+                          on sys_hff.MON_SYS_ID = hff.MON_SYS_ID
+                        join camdecmpswks.HRLY_PARAM_FUEL_FLOW hpff
+                          on hpff.RPT_PERIOD_ID = hff.RPT_PERIOD_ID
+                         and hpff.MON_LOC_ID = hff.MON_LOC_ID
+                         and hpff.HRLY_FUEL_FLOW_ID = hff.HRLY_FUEL_FLOW_ID
+                         and hpff.PARAMETER_CD in ( 'HI', 'NOXR' )
+                        left join camdecmpswks.MONITOR_SYSTEM sys_hpff
+                          on sys_hpff.MON_SYS_ID = hpff.MON_SYS_ID
+                        left join camdecmpswks.DERIVED_HRLY_VALUE dhv
+                          on dhv.RPT_PERIOD_ID = hod.RPT_PERIOD_ID
+                         and dhv.MON_LOC_ID = hod.MON_LOC_ID
+                         and dhv.HOUR_ID = hod.HOUR_ID
+                         and dhv.PARAMETER_CD in ( 'HI', 'NOX', 'NOXR' )
+                        left join camdecmpswks.MONITOR_FORMULA frm
+                          on frm.MON_FORM_ID = dhv.MON_FORM_ID
+                 group
+                    by  mpl.MON_PLAN_ID, 
+                        hod.MON_LOC_ID, 
+                        hod.RPT_PERIOD_ID,
+                        hod.BEGIN_DATE,
+                        hod.BEGIN_HOUR,
+                        hod.OP_TIME,
+                        hod.HR_LOAD,
+                        hod.LOAD_UOM_CD,
+                        hff.FUEL_CD,
+                        hff.FUEL_USAGE_TIME,
+                        sys_hff.SYSTEM_IDENTIFIER,
+                        ems.CHK_SESSION_ID
+            ) dat
+     where  dat.NOXR_HRLY_FUEL_FLOW_ID is not null;
+
+    RAISE NOTICE 'Refreshing view counts...';
+    CALL camdecmpswks.refresh_emission_view_count(vmonplanid, vrptperiodid, 'NOXAPPESINGLEFUEL');
+END
+$procedure$


### PR DESCRIPTION
## Affected Columns

For the affected Emission View columns below, changed the populating procedures in both Official and Workspace to store an `empty string` instead of a null,

| Emission View Table | Column | Official/Workspace | Procedure Name |
| :--- | :--- | :--: | :--- |
| EMISSION_VIEW_HIAPPD              | FUEL_SYS_ID   | Both | refresh_emission_view_hiappd |
| EMISSION_VIEW_NOXAPPESINGLEFUEL   | FUEL_SYS_ID   | Both | refresh_emission_view_noxappesinglefuel |

## Affected Scripts

Changed the scripts for the following Emission View tables to indicate `not null` for the columns specified below.

| Schema | Table | Column |
| :--- | :--- | :--- |
| CAMDECMPS | EMISSION_VIEW_CO2APPD | FUEL_SYS_ID |
| CAMDECMPS | EMISSION_VIEW_CO2DAILYFUEL | FUEL_CD |
| CAMDECMPS | EMISSION_VIEW_DAILYCAL | TEST_SUM_ID |
| CAMDECMPS | EMISSION_VIEW_HIAPPD | FUEL_SYS_ID |
| CAMDECMPS | EMISSION_VIEW_MASSOILCALC | FUEL_SYS_ID |
| CAMDECMPS | EMISSION_VIEW_NOXAPPESINGLEFUEL | FUEL_SYS_ID |
| CAMDECMPS | EMISSION_VIEW_OTHERDAILY | TEST_SUM_ID |
| CAMDECMPS | EMISSION_VIEW_SO2APPD | FUEL_SYS_ID |
