### PR TITLE
Fix/7213 appehigas wrong column headers

### DIFF
--- a/deployments/ecmps/release-v2.0/report-definitions/rpt-qa-test-printout-load.sql
+++ b/deployments/ecmps/release-v2.0/report-definitions/rpt-qa-test-printout-load.sql
@@ -477,10 +477,10 @@ BEGIN
 		(datatableId, 1, 'operatingLevelNo', 'Operating Level No.'),
 		(datatableId, 2, 'runNo', 'Run No.'),
 		(datatableId, 3, 'sysId', 'System ID'),
-		(datatableId, 4, 'gasGCV', 'Oil Mass (lb)'),
-		(datatableId, 5, 'gasVolume', 'Oil GCV'),
-		(datatableId, 6, 'gasHI', 'Oil GCV UOM'),
-		(datatableId, 7, 'calculatedGasHI', 'Oil Volume');		
+		(datatableId, 4, 'gasGCV', 'Gas GCV'),
+		(datatableId, 5, 'gasVolume', 'Gas Volume'),
+		(datatableId, 6, 'gasHI', 'Reported Gas HI'),
+		(datatableId, 7, 'calculatedGasHI', 'Recalculated Gas HI');
 			/***** PARAMETERS *****/
 	INSERT INTO camdaux.dataparameter(datatable_id, parameter_order, name, default_value)
 	VALUES (datatableId, 1, 'testId', null);

--- a/deployments/ecmps/release-v2.3/Sprint43/7213/datacolumn.sql
+++ b/deployments/ecmps/release-v2.3/Sprint43/7213/datacolumn.sql
@@ -1,0 +1,34 @@
+DO $$
+DECLARE
+    datatableId integer := (
+        SELECT
+            datatable_id
+        FROM
+            camdaux.datatable
+        WHERE
+            dataset_cd = 'TEST_DETAIL'
+            AND template_cd = 'APPEHIGAS'
+            AND table_order = 12
+    );
+BEGIN
+    UPDATE camdaux.datacolumn
+    SET display_name = 'Gas GCV'
+    WHERE datatable_id = datatableId
+        AND name = 'gasGCV';
+
+    UPDATE camdaux.datacolumn
+    SET display_name = 'Gas Volume'
+    WHERE datatable_id = datatableId
+        AND name = 'gasVolume';
+
+    UPDATE camdaux.datacolumn
+    SET display_name = 'Reported Gas HI'
+    WHERE datatable_id = datatableId
+        AND name = 'gasHI';
+
+    UPDATE camdaux.datacolumn
+    SET display_name = 'Recalculated Gas HI'
+    WHERE datatable_id = datatableId
+        AND name = 'calculatedGasHI';
+END
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/7213

## Main Changes:

- Fixed incorrect display names for several Appendix E Heat Input from Gas report columns specified in the CAMDAUX.DATA_COLUMN table. The columns were using labels intended for Appendix E Heat Input from Oil columns. 